### PR TITLE
ci: add Claude blocking review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,13 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v1
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets:
+      claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds the reusable Claude blocking review workflow from `smartwatermelon/github-workflows`
- Triggers on all PRs (opened, synchronize)
- Requires `CLAUDE_CODE_OAUTH_TOKEN` secret to be configured

## Setup required
After merge, add the `CLAUDE_CODE_OAUTH_TOKEN` repository secret and optionally add `claude-review / run-review` as a required status check in branch protection.

## Test plan
- [ ] Verify `CLAUDE_CODE_OAUTH_TOKEN` secret is set on the repo
- [ ] Open a test PR to confirm the review workflow runs
- [ ] Optionally enable branch protection rule for `claude-review / run-review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)