### PR TITLE
fix: add permissions to caller workflow for reusable review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
 jobs:
   claude-review:
     uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v1


### PR DESCRIPTION
## Summary
- Fixes `startup_failure` on `claude-review` workflow — same issue fixed in ralph-burndown#43
- The reusable `claude-blocking-review.yml` needs `contents:read`, `pull-requests:write`, `issues:write`, `id-token:write`
- Without explicit permissions in the caller, they default to `none`

## Test plan
- [ ] `claude-review / run-review` check triggers on this PR

🤖 Generated with [Claude Code](https://claude.ai/code)