### PR TITLE
docs(readme): add claude-wrapper to implementations table

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The spec in this repo is implemented across several other repositories. None of 
 | Repo | What it contains |
 | --- | --- |
 | [`smartwatermelon/claude-config`](https://github.com/smartwatermelon/claude-config) | The actual Claude Code hooks: `pre-merge-review.sh`, `run-review.sh`, `merge-lock.sh`, `lib-review-issues.sh`. Symlinked into `~/.claude/` on each machine. |
+| [`smartwatermelon/claude-wrapper`](https://github.com/smartwatermelon/claude-wrapper) | Bash wrapper around the `claude` CLI, symlinked to `~/.local/bin/claude` so it shadows the real binary in `$PATH`. Resolves per-project 1Password secrets via `op inject`, injects `--remote-control` session names for interactive sessions, and validates binary ownership/permissions before `exec`. |
 | [`smartwatermelon/dotfiles`](https://github.com/smartwatermelon/dotfiles) | The global git hooks (`pre-commit`, `pre-push`, `commit-msg`, etc.) at `git/hooks/`, symlinked from `~/.config/git/hooks/`. Also hosts shared shell utilities like `lint-shell.sh`. |
 | [`smartwatermelon/github-workflows`](https://github.com/smartwatermelon/github-workflows) | The reusable GitHub Actions workflows (`claude-blocking-review.yml`, `claude-assistant.yml`) called by every owned repo's `.github/workflows/` caller. Plus `claude-review-audit.sh` for fleet-wide configuration auditing. |
 | [`smartwatermelon/ralph-burndown`](https://github.com/smartwatermelon/ralph-burndown) | The tech-debt burndown tool that picks up non-blocking issues filed by the local Phase 2 review and works through them overnight. |


### PR DESCRIPTION
## Summary

- Adds `claude-wrapper` to the "Where the implementations live" table in `README.md`.
- The wrapper is the PATH-shim that shadows the real `claude` CLI to inject 1Password secrets, GitHub tokens, and remote-control session names. It deploys differently from `claude-config` (single binary symlinked into `~/.local/bin/` vs. directory tree symlinked into `~/.claude/`), so it warrants its own row.

## Context

Spotted while discussing whether `claude-wrapper` and `claude-config` should be merged. They shouldn't — they have distinct deployment shapes and distinct blast radii — but the spec didn't reflect that the wrapper is a sibling implementation. Now it does.

## Notes

Pre-push codebase review surfaced an unrelated pre-existing issue in `docs/WORKFLOW-DEEP-DIVE.md:310` (mislabels `claude-wrapper` as "this repo"), filed as #25 for the burndown tool. Not in scope for this PR.

## Test plan

- [x] `markdownlint` passes
- [x] Pre-push adversarial-reviewer + codebase-reviewer PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)