### PR TITLE
fix(ci): downgrade blocking review model to Haiku

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -15,5 +15,6 @@ jobs:
     uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3.0.0
     with:
       pr_number: ${{ github.event.pull_request.number }}
+      model: "claude-haiku-4-5-20251001"
     secrets:
       claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Downgrade CI blocking review model from Sonnet to Haiku
- This is a docs/config repo where Sonnet-level review is unnecessary

## Test plan
- [ ] Verify blocking review runs with Haiku model on next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)