### PR TITLE
fix(security): float claude-blocking-review ref to @v3 (GHSA-8q5r-mmjf-575q)

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -12,13 +12,13 @@ permissions:
 
 jobs:
   claude-review:
-    # Pinned to v3.1.0+, not a caller-level `if: github.actor !=
+    # Floating @v3, not a caller-level `if: github.actor !=
     # 'dependabot[bot]'` gate — a job-level `if:` prevents this job from
     # ever reporting on Dependabot PRs, which leaves a required status
-    # check permanently pending. v3.1.0+ skips Dependabot PRs from
-    # inside the job instead, so it still reports PASS. See
+    # check permanently pending. The reusable workflow skips Dependabot
+    # PRs from inside the job instead, so it still reports PASS. See
     # smartwatermelon/github-workflows#115/#117.
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3.1.0
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3
     with:
       pr_number: ${{ github.event.pull_request.number }}
       model: "claude-haiku-4-5-20251001"


### PR DESCRIPTION
## Active security exposure

This repo pins its Claude blocking-review caller at `@v3.1.0`. That tag is immutable and predates the GHSA-8q5r-mmjf-575q fix, so every run has been resolving to `anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44` — v1.0.70, **vulnerable**.

The fleet-wide remediation was applied by repointing the floating `v3` tag in `smartwatermelon/github-workflows`. This repo doesn't use `@v3`, so it never received the fix.

Verified:

| ref | resolves to | status |
| --- | --- | --- |
| `@v3.1.0` | `claude-code-action@26ec0412` (v1.0.70) | vulnerable |
| `@v3` | `claude-code-action@9d7150bc` (v1.0.193) | patched |

## The change

```diff
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3.1.0
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3
```

Only the ref changed. Nothing else in the file was touched.

## Why float instead of bumping the pin

Floating `@v3` means future security fixes propagate by repointing one tag in `github-workflows`, instead of requiring a PR in every consumer repo. That's the intended fleet model — exact pins silently opted this repo out of remediation for months, which is exactly the failure this PR fixes. Bumping to a new exact pin would just reset the same trap.

The trust boundary is unchanged: `@v3` is a tag in the same org's `github-workflows` repo, not a third-party action.

## Notes

- The caller comment referencing `v3.1.0+` was updated to describe the floating ref; its substance (job-internal Dependabot skip, not a caller-level `if:` gate) is unchanged and still accurate.
- The pre-commit `zizmor` `unpinned-uses` finding on the tag ref is deliberate fleet policy, documented at `README.md:207` in `github-workflows`. Committed with `SKIP=zizmor` and noted in the commit message.
- `claude-review / run-review` is expected to report `pass` via the `workflow-self-modification` skip path, since this PR touches `.github/workflows/`.

https://claude.ai/code/session_01SimcNSM4P5hpb1dQVejqcF
