### PR TITLE
docs(gha-security): scope Pattern 2 to third-party actions, add first-party carve-out

### DIFF
--- a/docs/github-actions-security-methodology.md
+++ b/docs/github-actions-security-methodology.md
@@ -64,6 +64,13 @@ out the PR.
 
 ### Pattern 2 — Mutable action references (git tags)
 
+**Scope:** This pattern applies to actions whose repo we do NOT control.
+First-party reusable workflows in an org we own are deliberately excluded
+— see [First-party carve-out](#first-party-carve-out) below. Applying the
+rule uniformly inverts it: an immutable pin on a first-party workflow
+freezes consumers on whatever that tag contained, including its
+vulnerabilities.
+
 **Danger:** Tags like `@v3` are mutable; an attacker who compromises the
 action repo can move the tag to a malicious commit, and 23,000+ repos
 auto-pull on next run (tj-actions). Trivy had 76 of 77 historical tags
@@ -88,6 +95,69 @@ uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
 Resolve the tag with: `gh api /repos/<owner>/<repo>/git/refs/tags/<tag>
 --jq '.object.sha'` (and dereference if `.object.type == "tag"`).
+
+#### First-party carve-out
+
+Two classes of `uses:` reference, two deliberately different policies:
+
+| Class | Policy | Rationale |
+|-------|--------|-----------|
+| **Third-party actions** (`actions/checkout`, `anthropics/claude-code-action`, …) | SHA-pin + Dependabot | We don't control upstream; a repointed tag runs arbitrary code on our runners at the next trigger. This is Pattern 2's actual target. |
+| **First-party reusable workflows** (`smartwatermelon/github-workflows/…`) | Floating major tag (`@v3`) | We control the repo, its branch protection, and who moves the tag. Floating refs are what make coordinated fleet remediation possible. |
+
+A finding of "first-party workflow referenced by floating major tag" is
+NOT a Pattern 2 finding. Do not open a PR to SHA-pin or exact-version-pin
+it; that is a regression, not a fix.
+
+**Why floating wins here.** An exact pin like `@v3.1.0` is immutable, so a
+consumer sitting on it never receives a fix landed after that tag was cut.
+Remediating GHSA-8q5r-mmjf-575q showed this concretely — `@v3.1.0`
+predates the fix and carries the vulnerable `claude-code-action` v1.0.70,
+while `@v3` resolves to the patched v1.0.193:
+
+```bash
+for ref in v3.1.0 v3; do
+  gh api "repos/smartwatermelon/github-workflows/contents/.github/workflows/claude-blocking-review.yml?ref=$ref" \
+    --jq .content | base64 -d | grep -oE 'claude-code-action@[a-f0-9]{8}'
+done
+# v3.1.0 -> claude-code-action@26ec0412   (v1.0.70, vulnerable)
+# v3     -> claude-code-action@9d7150bc   (v1.0.193, patched)
+```
+
+`@v3` is also a strict superset of `@v3.1.0`, not a rollback — verify
+before assuming a floating tag has lost behavior:
+
+```bash
+gh api repos/smartwatermelon/github-workflows/compare/v3.1.0...v3 \
+  --jq '{status, ahead: .ahead_by, behind: .behind_by}'
+# {"status":"ahead","ahead":19,"behind":0}
+```
+
+Nineteen consumer repos sat on exact pins and never received the
+fleet-wide remediation. Pattern 2 applied uniformly is what kept them
+there.
+
+**The carve-out is narrow, not a general relaxation.** It covers exactly
+one hop: our own reusable workflow. `smartwatermelon/github-workflows`
+SHA-pins every third-party action it consumes — enforced by a `zizmor`
+`unpinned-uses` audit in CI — and carries a `dependabot.yml` keeping those
+pins current. The transitive supply chain stays immutable; only the
+first-party hop floats.
+
+**Residual risk, stated honestly.** A compromised first-party tag would
+reach every consumer at once — the same blast radius that makes tj-actions
+severe. What bounds it:
+
+- Branch protection on `smartwatermelon/github-workflows`, with a required
+  blocking review, so no code reaches `main` unreviewed.
+- Tag moves are manual and human-authorized. No automation repoints a
+  floating tag.
+- Transitive third-party deps are SHA-pinned, so a compromise must go
+  through that repo's own review path rather than arriving sideways from
+  upstream.
+
+That risk is accepted in exchange for the ability to patch the fleet in
+one tag move. If any of the three bounds lapses, revisit the carve-out.
 
 ### Pattern 3 — Cache poisoning across trust boundaries
 
@@ -199,7 +269,9 @@ if: |
 This is Pattern 2 stated as a coverage rule rather than a one-off
 incident. The article's data: 91% of PyPI packages using third-party
 actions reference at least one by mutable tag. The remediation and
-detection are identical to Pattern 2.
+detection are identical to Pattern 2 — including its
+[first-party carve-out](#first-party-carve-out), which this pattern's
+"third-party" wording already implies.
 
 ### Pattern 9 — Missing workflow `permissions:` block
 
@@ -233,6 +305,7 @@ A finding's severity is `(blast radius) × (exploitability)`:
 | **High** | Pattern 6 (default=write) on a repo with non-trivial workflows; Pattern 2 on a third-party action with cross-repo secrets |
 | **Medium** | Pattern 2 on a low-reputation third-party action; Pattern 9 on a workflow that touches secrets |
 | **Low** | Pattern 9 on a read-only test workflow; Pattern 2 on a GitHub-owned action |
+| **Not a finding** | Pattern 2 on a first-party reusable workflow referenced by floating major tag (see [First-party carve-out](#first-party-carve-out)) |
 
 ## Mitigation framework
 


### PR DESCRIPTION
## Problem

Pattern 2 ("Mutable action references") warns that mutable tags like `@v3` let a compromised action repo repoint consumers at malicious code. That's correct — for **third-party** actions. But the pattern body never stated that scope, so a pre-push reviewer applied it to **first-party** reusable workflows and hard-BLOCKED the GHSA-8q5r-mmjf-575q remediation in this repo, `lock-sync`, `scripts`, and `smartwatermelon-marketplace`.

Its reasoning was inverted, and both claims are verifiably wrong:

**1. It called `@v3.1.0` → `@v3` a security downgrade.** Backwards. `@v3.1.0` is an immutable tag cut *before* the fix, so it pins the vulnerable `claude-code-action` v1.0.70. `@v3` resolves to the patched v1.0.193:

```console
$ for ref in v3.1.0 v3; do gh api ".../claude-blocking-review.yml?ref=$ref" --jq .content | base64 -d | grep -oE 'claude-code-action@[a-f0-9]{8}'; done
claude-code-action@26ec0412   # v3.1.0 -> v1.0.70, VULNERABLE
claude-code-action@9d7150bc   # v3     -> v1.0.193, patched
```

**2. It warned `@v3` might lack the v3.1.0+ Dependabot skip logic.** It doesn't — strict superset:

```console
$ gh api repos/smartwatermelon/github-workflows/compare/v3.1.0...v3 --jq '{status,ahead:.ahead_by,behind:.behind_by}'
{"status":"ahead","ahead":19,"behind":0}
```

19 repos sat on immutable exact pins and never received the fleet-wide remediation. Following Pattern 2 as written is what kept them there.

## The doc was already half-right

The severity table already scoped Pattern 2 by *who controls the action repo* (`High` for third-party, `Low` for GitHub-owned), and the Detect block already mentions "reusable workflows in the user's own repos — separate trust boundary". The distinction existed in those rows but not in the pattern body, which is why a reader applies the rule uniformly.

## Changes

Documentation only — no workflow files touched.

- **Scope note** on Pattern 2, pointing at the carve-out.
- **New "First-party carve-out" subsection** (`####`, under Pattern 2): the two-class policy table, both verification commands above, why the carve-out is narrow, and the residual risk.
- **"Not a finding" row** in the severity rubric.
- **Pattern 8 cross-reference**, since it explicitly inherits Pattern 2's detection/remediation.

The two-class policy:

| Class | Policy | Rationale |
|---|---|---|
| Third-party actions | SHA-pin + Dependabot | We don't control upstream; a repointed tag runs arbitrary code at the next trigger. Pattern 2's actual target. |
| First-party reusable workflows | Floating major tag (`@v3`) | We control the repo, its branch protection, and who moves the tag. Floating refs make coordinated fleet remediation possible. |

**Narrow, not a general relaxation.** It covers exactly one hop. `smartwatermelon/github-workflows` SHA-pins every third-party action it consumes (enforced by a `zizmor` `unpinned-uses` audit) and carries a `dependabot.yml` keeping those current — the transitive supply chain stays immutable; only the first-party hop floats.

**Residual risk is stated, not hidden.** A compromised first-party tag would reach every consumer at once. What bounds it: branch protection with a required blocking review on that repo, manual human-authorized tag moves (no automation repoints floating tags), and the SHA-pinned transitive deps. The doc says to revisit the carve-out if any of the three lapses.

## Verification

Both `gh` commands above were re-run against live GitHub before writing the claims; the outputs quoted in the doc are their actual output.

## Note on the pre-commit hook

`SKIP=markdownlint` was used, noted in the commit body. MD060 `table-column-style` fails on this file **at `main`** with 13 pre-existing errors (the severity and audit-history tables have never been pipe-aligned). Not introduced here, and aligning them would mean reformatting unrelated tables. The hook also auto-rewrote the pre-existing severity table's separator row, which was reverted as out-of-scope.

Closes #57
