### PR TITLE
docs: mark the contamination handoff as superseded in part

### DIFF
--- a/docs/2026-08-24-dotfiles-config-contamination-handoff.md
+++ b/docs/2026-08-24-dotfiles-config-contamination-handoff.md
@@ -1,5 +1,15 @@
 # Handoff: dotfiles `.git/config` contamination (smartwatermelon/dotfiles#239)
 
+> **⚠️ Superseded in part — read
+> [`2026-08-25-dotfiles-config-contamination-response.md`](2026-08-25-dotfiles-config-contamination-response.md)
+> alongside this document.** That analysis assesses six claims below as False,
+> Incomplete, Insufficient, Misleading, or Unsupported — see its "Corrections to
+> the handoff" section. Most importantly, the `git -C "${dir}"` remediation
+> proposed here does **not** override an inherited `GIT_DIR`, so applying it as
+> written will not fix the contamination. The worktree timeline here is also
+> corrected there. This document is kept for the investigation record; the
+> response doc carries the current conclusions.
+
 **Status as of 2026-08-24 19:25 PDT:** config cleaned, tripwire armed, root
 cause **still unidentified**. Issue #239 reopened.
 


### PR DESCRIPTION
The response doc assesses six of the handoff's claims as False, Incomplete, Insufficient, Misleading, or Unsupported, but the two documents sit side by side with nothing pointing from the older one to the newer.

A reader who opens only the handoff acts on the superseded conclusion — in particular the `git -C "${dir}"` remediation, which the response shows does **not** override an inherited `GIT_DIR` and so would not fix the contamination.

Adds a banner at the top of the handoff linking to the response and naming that specific correction. The handoff stays as the investigation record.

## Also verified while working #65 and #67

Three of the four batched findings turned out to be **already done**:

- **#65.1 / #67.2c** — the `core.bare` assertion exists in dotfiles at `bash/tests/test-git-config-hygiene.sh:165-184` ("core.bare is true, but this repo has a work tree").
- **#67.2a/b** — dotfiles has `bash/tests/test-git-env-isolation.sh`, a full inherited-`GIT_DIR` regression test. It includes a control case that fails loudly if the contamination stops reproducing, so a green run cannot be vacuous.
- **#65.2** — audited every `gh search` invocation across `~/Developer` and `~/.claude`. The only real one is `scripts/open-prs.sh:139`, which already uses the correct `--archived=false` equals form, with a comment at `:126` explaining why the space form is wrong.

Advances #67

https://claude.ai/code/session_01JDSkWf5WuCr1bGeUgPJc6h