### PR TITLE
chore(org-migration): baseline snapshot of the 31 move-list repos

### DIFF
--- a/docs/data/org-migration/2026-09-04-baseline/.github.json
+++ b/docs/data/org-migration/2026-09-04-baseline/.github.json
@@ -1,0 +1,60 @@
+{
+  "repo": ".github",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": [],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/.github/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/.github/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": [],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/.github/branches/main/protection/required_status_checks/contexts",
+      "checks": []
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/.github/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/.github/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/.github/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/archive-resolver.json
+++ b/docs/data/org-migration/2026-09-04-baseline/archive-resolver.json
@@ -1,0 +1,65 @@
+{
+  "repo": "archive-resolver",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": ["archive-today", "bash", "macos", "mirror", "archive-is"],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/archive-resolver/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/archive-resolver/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/archive-resolver/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": null
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/archive-resolver/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/archive-resolver/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/archive-resolver/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/claude-code-workflows-agents.json
+++ b/docs/data/org-migration/2026-09-04-baseline/claude-code-workflows-agents.json
@@ -1,0 +1,15 @@
+{
+  "repo": "claude-code-workflows-agents",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": null,
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/claude-config-backup.json
+++ b/docs/data/org-migration/2026-09-04-baseline/claude-config-backup.json
@@ -1,0 +1,15 @@
+{
+  "repo": "claude-config-backup",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "private",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": [],
+  "protection": null,
+  "rulesets": null
+}

--- a/docs/data/org-migration/2026-09-04-baseline/claude-config.json
+++ b/docs/data/org-migration/2026-09-04-baseline/claude-config.json
@@ -1,0 +1,74 @@
+{
+  "repo": "claude-config",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [
+    "ai-tools",
+    "anthropic",
+    "claude-ai",
+    "claude-code",
+    "code-review",
+    "developer-tools",
+    "dotfiles",
+    "git-hooks"
+  ],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/claude-config/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/claude-config/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/claude-config/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/claude-config/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/claude-config/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/claude-config/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/claude-wrapper.json
+++ b/docs/data/org-migration/2026-09-04-baseline/claude-wrapper.json
@@ -1,0 +1,92 @@
+{
+  "repo": "claude-wrapper",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [
+    "1password",
+    "bash",
+    "claude-code",
+    "cli-wrapper",
+    "github-token",
+    "shell"
+  ],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/claude-wrapper/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/claude-wrapper/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/claude-wrapper/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/claude-wrapper/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/claude-wrapper/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/claude-wrapper/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": [
+    {
+      "id": 12712615,
+      "name": "main",
+      "target": "branch",
+      "source_type": "Repository",
+      "source": "smartwatermelon/claude-wrapper",
+      "enforcement": "active",
+      "node_id": "RRS_lACqUmVwb3NpdG9yec5DoIh1zgDB-qc",
+      "_links": {
+        "self": {
+          "href": "https://api.github.com/repos/smartwatermelon/claude-wrapper/rulesets/12712615"
+        },
+        "html": {
+          "href": "https://github.com/smartwatermelon/claude-wrapper/rules/12712615"
+        }
+      },
+      "created_at": "2026-02-11T12:47:15.588-08:00",
+      "updated_at": "2026-02-11T12:47:38.696-08:00"
+    }
+  ]
+}

--- a/docs/data/org-migration/2026-09-04-baseline/cleanroom.json
+++ b/docs/data/org-migration/2026-09-04-baseline/cleanroom.json
@@ -1,0 +1,15 @@
+{
+  "repo": "cleanroom",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "private",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": null,
+  "rulesets": null
+}

--- a/docs/data/org-migration/2026-09-04-baseline/crazy-larry.json
+++ b/docs/data/org-migration/2026-09-04-baseline/crazy-larry.json
@@ -1,0 +1,65 @@
+{
+  "repo": "crazy-larry",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/crazy-larry/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/crazy-larry/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/crazy-larry/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/crazy-larry/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/crazy-larry/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/crazy-larry/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/dev-env.json
+++ b/docs/data/org-migration/2026-09-04-baseline/dev-env.json
@@ -1,0 +1,78 @@
+{
+  "repo": "dev-env",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [
+    "claude-code",
+    "code-quality",
+    "code-review",
+    "dev-environment",
+    "developer-experience",
+    "documentation",
+    "git-hooks",
+    "local-first",
+    "pre-commit",
+    "specification",
+    "standards",
+    "workflow-automation"
+  ],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/dev-env/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/dev-env/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/dev-env/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": null
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/dev-env/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/dev-env/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/dev-env/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/dotfiles.json
+++ b/docs/data/org-migration/2026-09-04-baseline/dotfiles.json
@@ -1,0 +1,65 @@
+{
+  "repo": "dotfiles",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/dotfiles/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/dotfiles/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/dotfiles/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/dotfiles/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/dotfiles/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/dotfiles/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/dumbify.json
+++ b/docs/data/org-migration/2026-09-04-baseline/dumbify.json
@@ -1,0 +1,60 @@
+{
+  "repo": "dumbify",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": ["dumbify", "humanizer", "llms-txt", "personify"],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/dumbify/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/dumbify/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": [],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/dumbify/branches/main/protection/required_status_checks/contexts",
+      "checks": []
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/dumbify/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/dumbify/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/dumbify/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": false
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/github-workflows.json
+++ b/docs/data/org-migration/2026-09-04-baseline/github-workflows.json
@@ -1,0 +1,65 @@
+{
+  "repo": "github-workflows",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": ["claude-code", "github-workflows"],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/github-workflows/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/github-workflows/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/github-workflows/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/github-workflows/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/github-workflows/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/github-workflows/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/gmail-newsletter-filter.json
+++ b/docs/data/org-migration/2026-09-04-baseline/gmail-newsletter-filter.json
@@ -1,0 +1,82 @@
+{
+  "repo": "gmail-newsletter-filter",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [
+    "automation",
+    "email-filter",
+    "gmail",
+    "gmail-api",
+    "google-apps-script",
+    "google-sheets",
+    "inbox-zero",
+    "newsletter"
+  ],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/gmail-newsletter-filter/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/gmail-newsletter-filter/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review", "test", "lint"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/gmail-newsletter-filter/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        },
+        {
+          "context": "test",
+          "app_id": 15368
+        },
+        {
+          "context": "lint",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/gmail-newsletter-filter/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/gmail-newsletter-filter/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/gmail-newsletter-filter/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/homebrew-tap.json
+++ b/docs/data/org-migration/2026-09-04-baseline/homebrew-tap.json
@@ -1,0 +1,65 @@
+{
+  "repo": "homebrew-tap",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/homebrew-tap/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/homebrew-tap/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/homebrew-tap/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/homebrew-tap/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/homebrew-tap/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/homebrew-tap/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/huddle-transcribe.json
+++ b/docs/data/org-migration/2026-09-04-baseline/huddle-transcribe.json
@@ -1,0 +1,60 @@
+{
+  "repo": "huddle-transcribe",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/huddle-transcribe/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/huddle-transcribe/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": [],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/huddle-transcribe/branches/main/protection/required_status_checks/contexts",
+      "checks": []
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/huddle-transcribe/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/huddle-transcribe/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/huddle-transcribe/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": false
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/lock-sync.json
+++ b/docs/data/org-migration/2026-09-04-baseline/lock-sync.json
@@ -1,0 +1,65 @@
+{
+  "repo": "lock-sync",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/lock-sync/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/lock-sync/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/lock-sync/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/lock-sync/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/lock-sync/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/lock-sync/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/mac-dev-server-setup.json
+++ b/docs/data/org-migration/2026-09-04-baseline/mac-dev-server-setup.json
@@ -1,0 +1,76 @@
+{
+  "repo": "mac-dev-server-setup",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [
+    "android-sdk",
+    "apple-silicon",
+    "automation",
+    "build-server",
+    "devops",
+    "mac-mini",
+    "macos",
+    "mobile-development",
+    "shell-script",
+    "xcode"
+  ],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/mac-dev-server-setup/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/mac-dev-server-setup/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/mac-dev-server-setup/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/mac-dev-server-setup/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/mac-dev-server-setup/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/mac-dev-server-setup/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/mac-server-setup.json
+++ b/docs/data/org-migration/2026-09-04-baseline/mac-server-setup.json
@@ -1,0 +1,100 @@
+{
+  "repo": "mac-server-setup",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [
+    "macos",
+    "mac-mini",
+    "apple-silicon",
+    "home-server",
+    "automation",
+    "server-setup",
+    "plex-media-server",
+    "homebrew",
+    "smb-mounting",
+    "1password-integration",
+    "launchagent",
+    "infrastructure-as-code",
+    "keychain-access",
+    "nfs-mount"
+  ],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/mac-server-setup/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/mac-server-setup/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/mac-server-setup/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/mac-server-setup/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/mac-server-setup/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/mac-server-setup/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": [
+    {
+      "id": 7590377,
+      "name": "protecc",
+      "target": "branch",
+      "source_type": "Repository",
+      "source": "smartwatermelon/mac-server-setup",
+      "enforcement": "active",
+      "node_id": "RRS_lACqUmVwb3NpdG9yec459OZbzgBz0ek",
+      "_links": {
+        "self": {
+          "href": "https://api.github.com/repos/smartwatermelon/mac-server-setup/rulesets/7590377"
+        },
+        "html": {
+          "href": "https://github.com/smartwatermelon/mac-server-setup/rules/7590377"
+        }
+      },
+      "created_at": "2025-08-21T17:39:35.050-07:00",
+      "updated_at": "2025-08-21T17:39:35.075-07:00"
+    }
+  ]
+}

--- a/docs/data/org-migration/2026-09-04-baseline/personify.json
+++ b/docs/data/org-migration/2026-09-04-baseline/personify.json
@@ -1,0 +1,69 @@
+{
+  "repo": "personify",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": ["claude", "claude-skills", "personify", "skill", "skill-md"],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/personify/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/personify/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["validate", "claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/personify/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "validate",
+          "app_id": 15368
+        },
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/personify/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/personify/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/personify/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": false
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/pr-review.json
+++ b/docs/data/org-migration/2026-09-04-baseline/pr-review.json
@@ -1,0 +1,15 @@
+{
+  "repo": "pr-review",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": null,
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/projectinsomnia.json
+++ b/docs/data/org-migration/2026-09-04-baseline/projectinsomnia.json
@@ -1,0 +1,65 @@
+{
+  "repo": "projectinsomnia",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": ["netlify-deployment", "rss", "website", "astro"],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/projectinsomnia/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/projectinsomnia/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/projectinsomnia/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/projectinsomnia/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/projectinsomnia/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/projectinsomnia/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/qwen-sidebar.json
+++ b/docs/data/org-migration/2026-09-04-baseline/qwen-sidebar.json
@@ -1,0 +1,65 @@
+{
+  "repo": "qwen-sidebar",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/qwen-sidebar/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/qwen-sidebar/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/qwen-sidebar/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/qwen-sidebar/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/qwen-sidebar/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/qwen-sidebar/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/repo-template.json
+++ b/docs/data/org-migration/2026-09-04-baseline/repo-template.json
@@ -1,0 +1,15 @@
+{
+  "repo": "repo-template",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": [],
+  "protection": null,
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/scripts.json
+++ b/docs/data/org-migration/2026-09-04-baseline/scripts.json
@@ -1,0 +1,15 @@
+{
+  "repo": "scripts",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "private",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": null,
+  "rulesets": null
+}

--- a/docs/data/org-migration/2026-09-04-baseline/slack-mcp.json
+++ b/docs/data/org-migration/2026-09-04-baseline/slack-mcp.json
@@ -1,0 +1,65 @@
+{
+  "repo": "slack-mcp",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/slack-mcp/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/slack-mcp/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/slack-mcp/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/slack-mcp/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/slack-mcp/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/slack-mcp/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/smartwatermelon-marketplace.json
+++ b/docs/data/org-migration/2026-09-04-baseline/smartwatermelon-marketplace.json
@@ -1,0 +1,65 @@
+{
+  "repo": "smartwatermelon-marketplace",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/smartwatermelon-marketplace/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/smartwatermelon-marketplace/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/smartwatermelon-marketplace/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/smartwatermelon-marketplace/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/smartwatermelon-marketplace/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/smartwatermelon-marketplace/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/spokane-snow.json
+++ b/docs/data/org-migration/2026-09-04-baseline/spokane-snow.json
@@ -1,0 +1,80 @@
+{
+  "repo": "spokane-snow",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": {
+    "url": "https://api.github.com/repos/smartwatermelon/spokane-snow/pages",
+    "status": "built",
+    "cname": null,
+    "custom_404": false,
+    "html_url": "https://smartwatermelon.github.io/spokane-snow/",
+    "build_type": "legacy",
+    "source": {
+      "branch": "main",
+      "path": "/"
+    },
+    "public": true,
+    "protected_domain_state": null,
+    "pending_domain_unverified_at": null,
+    "https_enforced": true
+  },
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/spokane-snow/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/spokane-snow/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/spokane-snow/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": null
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/spokane-snow/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/spokane-snow/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/spokane-snow/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/superpowers-marketplace.json
+++ b/docs/data/org-migration/2026-09-04-baseline/superpowers-marketplace.json
@@ -1,0 +1,15 @@
+{
+  "repo": "superpowers-marketplace",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": [],
+  "protection": null,
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/superpowers.json
+++ b/docs/data/org-migration/2026-09-04-baseline/superpowers.json
@@ -1,0 +1,15 @@
+{
+  "repo": "superpowers",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [],
+  "pages": null,
+  "secrets": [],
+  "protection": null,
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/swift-progress-indicator.json
+++ b/docs/data/org-migration/2026-09-04-baseline/swift-progress-indicator.json
@@ -1,0 +1,65 @@
+{
+  "repo": "swift-progress-indicator",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": ["macos", "shell-script", "swift"],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/swift-progress-indicator/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/swift-progress-indicator/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": ["claude-review / run-review"],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/swift-progress-indicator/branches/main/protection/required_status_checks/contexts",
+      "checks": [
+        {
+          "context": "claude-review / run-review",
+          "app_id": 15368
+        }
+      ]
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/swift-progress-indicator/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/swift-progress-indicator/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/swift-progress-indicator/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": true
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/docs/data/org-migration/2026-09-04-baseline/x-thread-reader.json
+++ b/docs/data/org-migration/2026-09-04-baseline/x-thread-reader.json
@@ -1,0 +1,69 @@
+{
+  "repo": "x-thread-reader",
+  "owner": {
+    "login": "smartwatermelon",
+    "type": "User"
+  },
+  "default_branch": "main",
+  "visibility": "public",
+  "archived": false,
+  "topics": [
+    "browser-extension",
+    "chrome-extension",
+    "manifest-v3",
+    "reader-mode",
+    "twitter",
+    "twitter-thread",
+    "twitter-threads",
+    "webextension"
+  ],
+  "pages": null,
+  "secrets": ["CLAUDE_CODE_OAUTH_TOKEN"],
+  "protection": {
+    "url": "https://api.github.com/repos/smartwatermelon/x-thread-reader/branches/main/protection",
+    "required_status_checks": {
+      "url": "https://api.github.com/repos/smartwatermelon/x-thread-reader/branches/main/protection/required_status_checks",
+      "strict": true,
+      "contexts": [],
+      "contexts_url": "https://api.github.com/repos/smartwatermelon/x-thread-reader/branches/main/protection/required_status_checks/contexts",
+      "checks": []
+    },
+    "required_pull_request_reviews": {
+      "url": "https://api.github.com/repos/smartwatermelon/x-thread-reader/branches/main/protection/required_pull_request_reviews",
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_signatures": {
+      "url": "https://api.github.com/repos/smartwatermelon/x-thread-reader/branches/main/protection/required_signatures",
+      "enabled": false
+    },
+    "enforce_admins": {
+      "url": "https://api.github.com/repos/smartwatermelon/x-thread-reader/branches/main/protection/enforce_admins",
+      "enabled": false
+    },
+    "required_linear_history": {
+      "enabled": false
+    },
+    "allow_force_pushes": {
+      "enabled": false
+    },
+    "allow_deletions": {
+      "enabled": false
+    },
+    "block_creations": {
+      "enabled": false
+    },
+    "required_conversation_resolution": {
+      "enabled": false
+    },
+    "lock_branch": {
+      "enabled": false
+    },
+    "allow_fork_syncing": {
+      "enabled": false
+    }
+  },
+  "rulesets": []
+}

--- a/scripts/org-migration/snapshot.sh
+++ b/scripts/org-migration/snapshot.sh
@@ -31,6 +31,17 @@ _optional() {
   elif grep -q '(HTTP 404)' "${err}"; then
     echo null
     rc=0
+  elif [[ "$1" == */branches/*/protection || "$1" == */rulesets ]] &&
+    grep -q 'Upgrade to GitHub Pro or make this repository public' "${err}"; then
+    # Branch protection and rulesets are not features on a private repo under
+    # a free plan (personal or organization). GitHub answers both endpoints
+    # with a 403 carrying this exact sentence, not a 404 — measured
+    # 2026-09-04 on smartwatermelon/{scripts,cleanroom,claude-config-backup}.
+    # It is an absence, and the same absence after the transfer, so `null`
+    # is the value verify.sh must compare. The same sentence on any other
+    # endpoint, and any other 403 here, is still a failure.
+    echo null
+    rc=0
   else
     why="$(tr '\n' ' ' <"${err}" || true)"
     printf 'snapshot: %s: %s\n' "$1" "${why}" >&2

--- a/scripts/org-migration/tests/test-snapshot.sh
+++ b/scripts/org-migration/tests/test-snapshot.sh
@@ -65,6 +65,23 @@ case "${path}" in
   repos/smartwatermelon/forbidden/pages) echo 'gh: Not Found (HTTP 404)' >&2; exit 1 ;;
   repos/smartwatermelon/forbidden/branches/main/protection) echo 'gh: Not Found (HTTP 404)' >&2; exit 1 ;;
   repos/smartwatermelon/ghost*) echo 'gh: Not Found (HTTP 404)' >&2; exit 1 ;;
+  # privrepo: a private repo under a free plan. GitHub answers the protection
+  # endpoint with THIS 403 (measured 2026-09-04), which means "feature not
+  # available", i.e. no protection — unlike the secrets 403 above.
+  repos/smartwatermelon/privrepo) echo '{"name":"privrepo","owner":{"login":"smartwatermelon","type":"User"},"default_branch":"main","visibility":"private","archived":false}' | emit ;;
+  repos/smartwatermelon/privrepo/topics) echo '{"names":[]}' | emit ;;
+  repos/smartwatermelon/privrepo/actions/secrets) echo '{"secrets":[]}' | emit ;;
+  repos/smartwatermelon/privrepo/rulesets) echo 'gh: Upgrade to GitHub Pro or make this repository public to enable this feature. (HTTP 403)' >&2; exit 1 ;;
+  repos/smartwatermelon/privrepo/pages) echo 'gh: Not Found (HTTP 404)' >&2; exit 1 ;;
+  repos/smartwatermelon/privrepo/branches/main/protection) echo 'gh: Upgrade to GitHub Pro or make this repository public to enable this feature. (HTTP 403)' >&2; exit 1 ;;
+  # proplan: the SAME sentence on a different endpoint must still fail — the
+  # exemption is scoped to branch protection, not to the sentence.
+  repos/smartwatermelon/proplan) echo '{"name":"proplan","owner":{"login":"smartwatermelon","type":"User"},"default_branch":"main","visibility":"private","archived":false}' | emit ;;
+  repos/smartwatermelon/proplan/topics) echo '{"names":[]}' | emit ;;
+  repos/smartwatermelon/proplan/actions/secrets) echo 'gh: Upgrade to GitHub Pro or make this repository public to enable this feature. (HTTP 403)' >&2; exit 1 ;;
+  repos/smartwatermelon/proplan/rulesets) echo '[]' | emit ;;
+  repos/smartwatermelon/proplan/pages) echo 'gh: Not Found (HTTP 404)' >&2; exit 1 ;;
+  repos/smartwatermelon/proplan/branches/main/protection) echo 'gh: Not Found (HTTP 404)' >&2; exit 1 ;;
   *) echo "stub: unexpected path ${path}" >&2; exit 2 ;;
 esac
 STUB
@@ -163,6 +180,32 @@ if [[ ! -e "${WORK}/out/forbidden.json" ]]; then
 else
   wrote="$(cat "${WORK}/out/forbidden.json" || true)"
   _fail "403 on secrets: wrote a snapshot anyway: ${wrote}"
+fi
+
+# Case 7: a private repo under a free plan. The protection endpoint's
+# "Upgrade to GitHub Pro" 403 is an absence, not a failure: the snapshot must
+# succeed with protection=null. Known-bad: before the exemption this failed
+# all three private repos on the real move list.
+rm -rf "${WORK}/out" && mkdir -p "${WORK}/out"
+printf 'privrepo\tsmartwatermelon\n' >"${WORK}/list-privrepo"
+out="$(PATH="${WORK}/bin:${PATH}" bash "${SNAPSHOT}" "${WORK}/list-privrepo" "${WORK}/out" 2>&1)"
+rc=$?
+f="${WORK}/out/privrepo.json"
+if [[ "${rc}" -eq 0 ]] && [[ -f "${f}" ]] && jq -e '.visibility=="private" and .protection==null and .rulesets==null' "${f}" >/dev/null; then
+  _pass "private repo, free plan: protection and rulesets 403 recorded as null, snapshot succeeds"
+else
+  _fail "private repo, free plan: expected rc 0, protection==null, rulesets==null; got rc=${rc} out=${out}"
+fi
+# The exemption is scoped to the protection endpoint: the same sentence on
+# the secrets endpoint is still a failure (recording [] would hide it).
+rm -rf "${WORK}/out" && mkdir -p "${WORK}/out"
+printf 'proplan\tsmartwatermelon\n' >"${WORK}/list-proplan"
+out="$(PATH="${WORK}/bin:${PATH}" bash "${SNAPSHOT}" "${WORK}/list-proplan" "${WORK}/out" 2>&1)"
+rc=$?
+if [[ "${rc}" -ne 0 && "${out}" == *proplan* && ! -e "${WORK}/out/proplan.json" ]]; then
+  _pass "Pro-plan 403 on secrets: still a failure, no snapshot written"
+else
+  _fail "Pro-plan 403 on secrets: expected non-zero naming proplan and no file, got rc=${rc} out=${out}"
 fi
 
 # Case 6: malformed line rejected before any API call.


### PR DESCRIPTION
Step 1 of docs/superpowers/specs/2026-09-03-org-migration-design.md. Advances #54.

## What

- `docs/data/org-migration/2026-09-04-baseline/` — one JSON per move-list repo (31 files, incl. `.github.json`): owner, default branch, visibility, archived, topics, pages, secret **names** (no values), branch protection, rulesets. `verify.sh` diffs the post-transfer snapshot against these with jq.
- `snapshot.sh`: on a private repo under the free plan GitHub answers the branch-protection and rulesets endpoints with a 403 ("Upgrade to GitHub Pro or make this repository public…"), not a 404. That is an absence, so those two endpoints now record `null`. Any other 403, and the same sentence on any other endpoint (e.g. secrets), still fails the repo. Measured on `scripts`, `cleanroom`, `claude-config-backup`.
- Tests: new `privrepo` (must snapshot with `null` protection/rulesets) and `proplan` (Pro sentence on secrets must still fail) stubs; suite 36/36.

## Verification

- `bash scripts/org-migration/tests/run-tests.sh` — 36 pass, 0 fail
- `shellcheck -S info scripts/org-migration/snapshot.sh` clean
- Grepped the baseline for token-shaped strings: none

https://claude.ai/code/session_01B7KFdvsQq7eLUGEi4pRQmX
