### PR TITLE
docs(token-rotation): record mint dates and the private-repo carve-out

### DIFF
--- a/docs/token-rotation.md
+++ b/docs/token-rotation.md
@@ -6,17 +6,30 @@ leaked: revoke and rotate.
 
 Org-level secrets (design:
 `docs/superpowers/specs/2026-09-03-org-migration-design.md`, Step 5). Free-plan
-org secrets do not reach private repos, so `scripts` keeps a repo-level
-token until it goes public.
+org secrets do not reach private repos, so every private repo that runs a
+Claude workflow keeps its own repo-level copy. Both orgs currently read as
+`plan=team`, which *would* deliver org secrets to private repos — do not rely
+on that. The Team plan was bought to file a support ticket and will be
+dropped; a repo whose copy was deleted on that basis fails silently at the
+downgrade.
 
 | Scope | Minted | Expires | Minted on |
 | --- | --- | --- | --- |
-| org `smartwatermelon` | | | |
-| org `nightowlstudiollc` | | | |
-| repo `smartwatermelon/scripts` | | | |
+| org `smartwatermelon` | 2026-09-04 | unrecorded | ASIAGO |
+| org `nightowlstudiollc` | 2026-07-01 | unrecorded | unrecorded |
+| repo `smartwatermelon/scripts` | 2026-07-29 | unrecorded | unrecorded |
+| repo `nightowlstudiollc/photo-game-poc` | 2026-03-02 | unrecorded | unrecorded |
+| repo `nightowlstudiollc/cleanroom` | 2026-08-31 | unrecorded | unrecorded |
 
-Each row has a Google Calendar event "Rotate CLAUDE_CODE_OAUTH_TOKEN (<scope>)"
-two weeks before the expiry date, pointing here.
+Minted dates are the secret's `updated_at` from
+`gh secret list`, which is when the value was last set — accurate for
+rotation planning. **Expiry is not recoverable from the API.** It exists only
+in what `claude setup-token` printed at mint time, so fill each row in at
+step 4 of the runbook below rather than reconstructing it later. Until a row
+has a real expiry, its calendar event cannot be scheduled.
+
+Each row gets a Google Calendar event "Rotate CLAUDE_CODE_OAUTH_TOKEN
+(<scope>)" two weeks before the expiry date, pointing here.
 
 ## Rotation runbook
 
@@ -37,7 +50,11 @@ between.
    ```bash
    env -u GH_TOKEN gh secret set CLAUDE_CODE_OAUTH_TOKEN --org smartwatermelon --visibility all
    # or --org nightowlstudiollc
-   # or, for scripts:  gh secret set CLAUDE_CODE_OAUTH_TOKEN -R smartwatermelon/scripts
+   # private repos each keep their own copy -- an org secret does not reach
+   # them on the Free plan:
+   #   gh secret set CLAUDE_CODE_OAUTH_TOKEN -R smartwatermelon/scripts
+   #   gh secret set CLAUDE_CODE_OAUTH_TOKEN -R nightowlstudiollc/photo-game-poc
+   #   gh secret set CLAUDE_CODE_OAUTH_TOKEN -R nightowlstudiollc/cleanroom
    ```
 
    Paste when prompted.


### PR DESCRIPTION
Step 6 of the org migration: the token-rotation doc shipped with an empty
table, and its private-repo rationale named only one repo.

## What changed

**Mint dates filled in**, from each secret's `updated_at` via `gh secret
list` — the date the value was last set, which is what rotation planning
needs.

**Expiry left blank, and the doc now says why.** It is not readable from
the API; it exists only in what `claude setup-token` printed at mint time.
Three empty cells otherwise read as an oversight, and a row without a real
expiry cannot get its calendar reminder either — so the blank is load-
bearing information, not a gap.

**Two rows added.** `photo-game-poc` and `cleanroom` are private repos
running Claude workflows, so they carry repo-level tokens for exactly the
reason `scripts` does. The doc named only `scripts`.

**A warning about the temporary Team plan.** Both orgs currently read as
`plan=team`, under which an org secret *does* reach private repos, which
would make all three repo-level copies look redundant. That plan was bought
to file a support ticket and will be dropped. Deleting a private repo's
token on the strength of it fails at the downgrade — silently, on repos
nobody is watching.

## Verification

- Mint dates read from the live API, not reconstructed
- Full org-migration test suite green (no test references this doc)
- markdownlint clean; codebase reviewer PASS
- The runbook's step-3 rerun command re-checked against the now
  org-owned `smartwatermelon/dev-env`

## Related

Filed alongside this: #85, the `scripts`-goes-public issue Step 6 calls for.

Remaining in Step 6: the calendar events (needs real expiry dates first)
and removing the wrapper's `smartwatermelon` login alias — the latter
gated on TILSIT and MIMOLETTE running runbook Part D, or `gh` breaks on
both machines.

https://claude.ai/code/session_01MM2jf6c7eNN4QMq32GdC5X
