### PR TITLE
docs(org-migration): add a local-remote repoint step to Task 11

### DIFF
--- a/docs/superpowers/plans/2026-09-03-org-migration.md
+++ b/docs/superpowers/plans/2026-09-03-org-migration.md
@@ -1898,7 +1898,49 @@ EOF
 
 Surface the issue URL.
 
-**Verified when:** Steps 1–4 done and reported.
+- [ ] **Step 5: Repoint any local clone whose `origin` drifted off `smartwatermelon/*`**
+
+The migration's "no remote changes" premise holds only for clones whose
+`origin` still says `smartwatermelon/<repo>`: those URLs are correct again
+once the repo lands in the org. A clone repointed at `twistedmelonman/<repo>`
+during the window between the rename and the transfer is a different case —
+it keeps working via redirect, so nothing fails loudly, but it no longer
+matches the intended end state.
+
+It also drops out of verification silently. `verify.sh`'s clone loop skips any
+remote that does not match `github.com[:/]smartwatermelon/` (`verify.sh:109`,
+`continue`), so a drifted clone is not checked and not reported — the run
+still prints a clean result. Do not read a passing `verify.sh` as evidence
+that every local clone was examined.
+
+Find and fix them:
+
+```bash
+for d in "${HOME}"/Developer/*/.git; do
+  dir="${d%/.git}"
+  url="$(git -C "${dir}" remote get-url origin 2>/dev/null || true)"
+  [[ "${url}" =~ github\.com[:/]twistedmelonman/ ]] || continue
+  repo="${url##*/}"; repo="${repo%.git}"
+  if grep -qE "^${repo}[[:space:]]+smartwatermelon$" \
+      /Users/andrewrich/Developer/dev-env/scripts/org-migration/move-list.txt; then
+    echo "repoint: ${dir##*/}  ${url}"
+    git -C "${dir}" remote set-url origin "git@github.com:smartwatermelon/${repo}.git"
+  fi
+done
+```
+
+Only repos on the move list with target `smartwatermelon` are repointed;
+forks and archived repos legitimately stay under `twistedmelonman`. Re-run
+`verify.sh` afterward and confirm each repointed clone now appears in its
+`ls-remote ok` output rather than being skipped.
+
+Known drift as of 2026-09-08, found by the loop above: `claude-config` and
+`huddle-transcribe`. `claude-config` was repointed while diagnosing a
+`gh pr create` failure — the stale `smartwatermelon` remote made `gh` build
+a cross-repo PR and fail with "No commits between …". `dev-env` and
+`dotfiles` were checked and are still on `smartwatermelon`.
+
+**Verified when:** Steps 1–5 done and reported.
 
 ---
 


### PR DESCRIPTION
Adds Step 5 to Task 11 (cleanup): repoint local clones whose `origin` drifted
off `smartwatermelon/*`.

## Why

The plan's "no repo URL or remote changes" premise holds only for clones whose
`origin` still reads `smartwatermelon/<repo>` — those URLs become correct again
once the repo lands in the org. A clone repointed to `twistedmelonman/<repo>`
during the window between the rename (Task 7) and the transfers (Tasks 8–9) is
a different case: GitHub's redirect keeps it working, so nothing fails loudly,
but it no longer matches the intended end state.

## The part worth reviewing

It also drops out of verification without saying so. `verify.sh`'s clone loop
skips any remote that doesn't match `github.com[:/]smartwatermelon/`
(`verify.sh:109`, `continue`), so a drifted clone is neither checked nor
reported — and the run still prints a clean result. A passing `verify.sh` is
therefore not evidence that every local clone was examined.

I documented this rather than changing `verify.sh`, since widening its match
is a real design call (it would also start checking clones that are supposed
to stay under `twistedmelonman`) and belongs with whoever picks up the
remaining migration work.

## Verification

Dry-ran the loop against `~/Developer`. Found two drifted clones:
`claude-config` (repointed while diagnosing a `gh pr create` failure — the
stale remote made `gh` build a cross-repo PR and fail with "No commits
between …") and `huddle-transcribe`. `dev-env` and `dotfiles` were checked and
are still on `smartwatermelon`.

The loop only repoints repos whose move-list target is `smartwatermelon`, so
forks and archived repos that legitimately stay under `twistedmelonman` are
left alone.

Advances #54.

https://claude.ai/code/session_018DBq9L9hnM7ZTLfZpUWUYh
