### PR TITLE
docs: refresh status for 2026-09-08 and record the W1 decisions

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -33,14 +33,14 @@ the design sketched: the personal account `smartwatermelon` was renamed to
 `twistedmelonman`, then `smartwatermelon` was re-created as an organization
 and repos transferred in.
 
-**25 of 30 repos moved. Five never will.** `dotfiles`, `claude-config`,
+**25 of 30 repos moved. Five are blocked pending a support ticket.** `dotfiles`, `claude-config`,
 `personify`, `huddle-transcribe`, `projectinsomnia` are blocked by GitHub's
-**popular repository namespace retirement** — a path is retired permanently
+**popular repository namespace retirement** — a path is retired
 when the repo saw >100 clones or >100 Actions runs in the week before a
 rename, or shipped a Marketplace action. Retirement binds the *string*, not
 the account, so the new org inherited the old user account's retired paths.
 It blocks transfer (HTTP 422) and creation alike. A support ticket is in
-flight; assume it will be denied.
+flight (4729524), reopened after the org's Team upgrade; Andrew is pursuing it.
 
 Three platform behaviors found the hard way, all now documented:
 
@@ -159,7 +159,7 @@ These are not oversights. Do not "fix" them without asking.
 | Splitting and rotating the shared token | **Deferred.** One token is installed in five places; a single rotation covers all of them. See `docs/token-rotation.md`. |
 | `dev-env` visibility | **Stays public.** Considered and rejected: gitleaks over 67 commits found nothing, there are 0 forks, and going private would spend Actions minutes against the private budget while breaking the calendar event's `blob/main` link. |
 | `photo-game-poc` token copy | **Parked.** Its secret predates the 2026-06-29 mint, so it holds an older token with no recorded expiry. The repo is archived and runs nothing. |
-| Five retired repo paths | **Support ticket 4729524.** Closed by GitHub 2026-09-04 as self-service-only; reopened after the org's Team upgrade; status requested 2026-09-08, no staff reply. Assume denial. The move-list now records `twistedmelonman` as their end state. |
+| Five retired repo paths | **Support ticket 4729524.** Closed by GitHub 2026-09-04 as self-service-only; reopened after the org's Team upgrade; status requested 2026-09-08, no staff reply. **Not given up on.** The move-list records `twistedmelonman` as an interim shim; flip back and re-run `transfer.sh` if the paths are released. |
 
 ## Standing methodology
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Infrastructure project status
 
-**As of 2026-09-05.** Point-in-time snapshot of the infrastructure backlog
+**As of 2026-09-08.** Point-in-time snapshot of the infrastructure backlog
 (`docs/superpowers/specs/2026-09-01-infrastructure-backlog-design.md`). The
 design doc is authoritative on *what* each item is and why; this file records
 *where things stand* and what to pick up next.
@@ -15,11 +15,11 @@ partly done. Local review and runtime EOL have not started.
 
 | Layer | State |
 | --- | --- |
-| Foundation (F) | F1, F4 done. F2, F3 open. |
+| Foundation (F) | F1, F3, F4 done. F2 open (latent hazard, not urgent). |
 | Identity / billing (I) | I3 done. I0, I1, I2 open. |
-| Fleet (W) | W0 done. W1, W2, W3 open — **critical path**. |
-| Local review (L) | Not started. L1 gates whether local review is real. |
-| Runtime EOL (N) | Not started. Node 20 past EOL since 2026-04-30. |
+| Fleet (W) | W0 done. W1, W2, W3 open — **critical path**. Design decisions taken 2026-09-08. |
+| Local review (L) | L1 done. L2, L3, L4, L5 open. |
+| Runtime EOL (N) | N1a done. N1b (product repos) open. |
 
 **Critical path: W1 → W2 → W3.** I3 and W0 have left it. Everything in L and
 N runs in parallel and depends on nothing.
@@ -86,48 +86,68 @@ protection in both orgs is classic per-repo branch protection. The gap was
 also smaller than reported: the transferred repos mostly carried their
 required check through intact.
 
+### Starter set — L1, N1a, F3 (2026-09-02/03)
+
+Executed per `docs/superpowers/plans/2026-09-02-infrastructure-backlog-starter-set.md`
+and previously unrecorded here:
+
+- **L1 — dotfiles config contamination.** Remediation (`git-env-isolation.sh`,
+  9 fixture tests, a known-bad control) had already landed; the starter set
+  removed the `uchg` tripwire on `dotfiles/.git/config`. Verified 2026-09-08:
+  no flag, `core.hooksPath` intact. Follow-up `dotfiles#304` records why the
+  flag is intentionally absent.
+- **N1a — local nvm default and infra-repo CI pins.** `~/.nvm/alias/default`
+  is `lts/krypton` (v24.19.0). `claude-code-workflows-agents#16` merged.
+- **F3 — `GH_TOKEN` precedence guard, cheap tier.** `dotfiles#302` merged:
+  the wrapper fails closed when `GH_TOKEN` resolves to a login other than the
+  one the repo owner maps to. Follow-up `dotfiles#303` (cache the lookup).
+
+### Migration cleanup (Steps 5–7) and the other two machines
+
+Org secret set (visibility `ALL`), `ralph-burndown` secret removed,
+`claude-code-login` and `smartwatermelon.github.io` deleted, #85 filed, #54
+closed. Runbook Part D verified on TILSIT and MIMOLETTE 2026-09-08 (both
+authenticate as `twistedmelonman`); MIMOLETTE's dotfiles clone was 15 commits
+behind and was fast-forwarded. The temporary login alias is now removable
+(migration plan Task 12).
+
 ## Open work, in priority order
 
-### Blocking nothing, but on the critical path
+### Critical path: W1 → W2 → W3
 
-**W1 — build `standards-check.yml`**, folding in `zizmor.yml` and branch
-protection. Then **W2** (fleet rollout, pilots first) and **W3** (retire the
-CI judgment reviewer). W2 now inherits a largely conformant fleet rather than
-one it must protect from scratch, so re-scope it against current state rather
-than the design's original numbers.
+Decisions taken 2026-09-08 (Andrew) that unblock W1 — see
+`docs/superpowers/plans/2026-09-08-backlog-remainder-roadmap.md`:
 
-Re-pick the W2 pilot. The design chose `scripts` because its check was
-"Pro-gated and therefore not enforced" — that reasoning expired at I3, and
-`scripts` now enforces normally.
+- **No judgment reviewer stays in CI.** `standards-check.yml` replaces
+  `claude-blocking-review.yml` outright; local hooks are the only judgment
+  pass. `claude-assistant.yml` is out of scope and keeps its token.
+- **`nightowl-restore-blocking-review.sh` is retired with W3.**
 
-### Should be done early
+W2 pilots, re-picked from repos with no enforcement today: `repo-template`,
+`pr-review`, `claude-code-workflows-agents`, `nightowlstudiollc/.github`.
+`scripts` is not a pilot (see #85).
 
-- **L1 — dotfiles config contamination.** Gates whether local review is real
-  at all. The design says do this first in the L track.
-- **N1a — local nvm default + infra-repo CI pins.** One command plus two CI
-  pins; removes an unpatched runtime from daily use. Node 20 has been past
-  EOL since 2026-04-30 (dev-env#78).
-- **F2 / F3** — owner-aware `git-identity.sh` and the `GH_TOKEN` precedence
-  guard. Both consume F1, which is done.
-- **I0** — `CLAUDE_CONFIG_DIR` billing-verification script; unblocks the
-  billing control and then I1.
+### Runs in parallel with W
 
-### Filed this session
+- **I0** — `CLAUDE_CONFIG_DIR` billing-verification script. Deliverable is a
+  script Andrew runs on the company machine.
+- **F2** — owner-aware `git-identity.sh`. Latent hazard only; do after I0.
+- **N1b** — product-repo Node bumps (`tensegrity`, `kebab-tax`,
+  `Gmail-MCP-Server`, `reliquarist`). Confirm each job reaches its Node
+  step before and after.
+- **L2 → L3, L4, L5** — deploy/edit separation, the false-OK pair
+  (claude-config#439, #451), doc hygiene, small unfiled items.
+- **#89** — add `claude-blocking-review.yml` + exemplar protection to
+  `smartwatermelon/.github` only; the other three stay ungated by decision.
+- **#90** — evaluate org rulesets on one test repo against a known-bad PR.
+- **#85** — full-history secret audit of `scripts`, then stop and report.
+- **#94** — Netlify publish verification for six sites (needs the Netlify
+  dashboard as the inventory of record).
 
-- **#89** — four repos have no enforced review check because they have **no
-  review workflow to require**: `smartwatermelon/.github`,
-  `claude-config-backup`, `superpowers`, `superpowers-marketplace`. Protecting
-  them as-is would report "protected" while enforcing nothing.
-  `smartwatermelon/.github` is in exactly that state today.
-- **#90** — evaluate org rulesets as the scaling mechanism. Per-repo
-  protection does not scale to new repos, and `repo-template` cannot carry
-  protection in the template. This is the real problem the disabled ruleset
-  was presumably meant to solve. Validate any ruleset against a known-bad
-  case before trusting it.
+### Filed 2026-09-05
+
 - **#84** — three conditions the org-migration design's failure table does
   not cover.
-- **#85** — make `smartwatermelon/scripts` public: secret audit, history
-  rewrite, branch protection.
 
 ## Deferred by decision
 
@@ -135,11 +155,11 @@ These are not oversights. Do not "fix" them without asking.
 
 | Item | Decision |
 | --- | --- |
-| Runbook Part D on TILSIT and MIMOLETTE | **Postponed 2026-09-05.** The `gh` wrapper's temporary `twistedmelonman=smartwatermelon` login alias (`~/.config/bash/gh-wrapper.sh:188`) stays in place until both machines run it. |
+| Runbook Part D on TILSIT and MIMOLETTE | **Done 2026-09-08.** Alias removal (migration plan Task 12) is unblocked. |
 | Splitting and rotating the shared token | **Deferred.** One token is installed in five places; a single rotation covers all of them. See `docs/token-rotation.md`. |
 | `dev-env` visibility | **Stays public.** Considered and rejected: gitleaks over 67 commits found nothing, there are 0 forks, and going private would spend Actions minutes against the private budget while breaking the calendar event's `blob/main` link. |
 | `photo-game-poc` token copy | **Parked.** Its secret predates the 2026-06-29 mint, so it holds an older token with no recorded expiry. The repo is archived and runs nothing. |
-| Five retired repo paths | **Support ticket in flight.** Assume denial and plan around the five paths staying dead. |
+| Five retired repo paths | **Support ticket 4729524.** Closed by GitHub 2026-09-04 as self-service-only; reopened after the org's Team upgrade; status requested 2026-09-08, no staff reply. Assume denial. The move-list now records `twistedmelonman` as their end state. |
 
 ## Standing methodology
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -107,7 +107,7 @@ and previously unrecorded here:
 Org secret set (visibility `ALL`), `ralph-burndown` secret removed,
 `claude-code-login` and `smartwatermelon.github.io` deleted, #85 filed, #54
 closed. Runbook Part D verified on TILSIT and MIMOLETTE 2026-09-08 (both
-authenticate as `twistedmelonman`); MIMOLETTE's dotfiles clone was 15 commits
+authenticate as `twistedmelonman`); MIMOLETTE's dotfiles clone was 35 commits
 behind and was fast-forwarded. The temporary login alias is now removable
 (migration plan Task 12).
 

--- a/docs/superpowers/plans/2026-09-08-backlog-remainder-roadmap.md
+++ b/docs/superpowers/plans/2026-09-08-backlog-remainder-roadmap.md
@@ -1,0 +1,340 @@
+# Backlog Remainder: Roadmap and Housekeeping Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the status record back in line with live state, close the last
+open migration task (the login alias), and fix the execution order for
+everything that remains in the infrastructure backlog.
+
+**Architecture:** Tasks 1–4 are small, fully specified, and executable now.
+Section "Roadmap" sequences the rest of the backlog; each stage there gets its
+own plan document when it starts, because W1 in particular needs a design pass
+before its tasks can be written without placeholders.
+
+**Tech Stack:** Markdown, bash 5, `gh`, the hermetic stub-`gh` test suite under
+`scripts/org-migration/tests/`, dotfiles' `bash/tests/run-tests.sh`.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-infrastructure-backlog-design.md`
+(the backlog) and `docs/superpowers/specs/2026-09-03-org-migration-design.md`
+(Steps 6–7, Task 12 of its plan).
+
+## Global Constraints
+
+- Never commit on `main`; branch as `claude/<type>-<desc>-<session>`.
+- `shellcheck -S info` clean on every shell file touched; no `# shellcheck disable`.
+- Every behavior change has a test that was observed failing before the fix.
+- Re-measure before acting on any number in a status document.
+- Text files end with a newline.
+
+## Decisions recorded 2026-09-08 (Andrew)
+
+These answer the four questions in `smartwatermelon/github-workflows#154` and
+the two open follow-ups from W0. They are inputs to the roadmap below.
+
+| Question | Decision |
+| --- | --- |
+| #154 Q1+Q2: keep a judgment reviewer in CI? | **Remove entirely.** Local hooks are the only judgment pass. No advisory CI reviewer. |
+| #154 Q3: `claude-assistant.yml` | Out of scope, keeps its token (as the issue states). |
+| #154 Q4: `nightowl-restore-blocking-review.sh` | **Retire with W3**, same PR. |
+| dev-env#89: which workflow-less repos get a review gate? | **`smartwatermelon/.github` only.** `claude-config-backup`, `superpowers`, `superpowers-marketplace` stay ungated; record that in #89 and close it when `.github` is done. |
+| dev-env#85: `scripts` public | **Audit only, then ask.** Run the history scan and report; the rewrite and the visibility flip each need a separate yes. |
+
+## Live state measured 2026-09-08
+
+| Claim | Evidence |
+| --- | --- |
+| Runbook Part D done on TILSIT | `env -u GH_TOKEN gh api user --jq .login` over SSH → `twistedmelonman`; dotfiles at `37f9b6f` |
+| Runbook Part D done on MIMOLETTE | same login; dotfiles was at `2ab0959` (2026-08-20), fast-forwarded to `37f9b6f` this session; missing `~/.config/git/hooks/lib-symlink-exclusions.sh` symlink added |
+| Task 12 gate ("section D ran on all three machines") | **satisfied** |
+| Migration Tasks 10, 11 done | org secret `CLAUDE_CODE_OAUTH_TOKEN` visibility `ALL`; `ralph-burndown` secret list empty; `claude-code-login` and `smartwatermelon.github.io` return 404; #85 filed; #54 CLOSED |
+| Task 13 Step 3 not done | migration spec line 3 still reads `APPROVED IN CHAT 2026-09-03` |
+| L1 done | `dotfiles/.git/config` carries no `uchg` flag; `core.hooksPath` = `~/.config/git/hooks`; starter-set Task 4 |
+| N1a done | `~/.nvm/alias/default` = `lts/krypton`; `which node` → v24.19.0; `claude-code-workflows-agents#16` merged |
+| F3 done | `dotfiles#302` MERGED (fail closed when `GH_TOKEN` overrides the resolved identity) |
+| Support ticket 4729524 | closed by GitHub 2026-09-04 as self-service-only; reopened same day after the Team upgrade; status ping sent 2026-09-08. No staff reply. Assume denial. |
+| Task 11 Step 5 loop flags `claude-config`, `huddle-transcribe` | both are retired paths; `twistedmelonman` is their correct remote. The move-list still says `smartwatermelon`, so the loop and `verify.sh` treat them as drift. |
+
+---
+
+### Task 1: Record the five retired paths in the move-list
+
+**Files:**
+
+- Modify: `scripts/org-migration/move-list.txt`
+- Test: `scripts/org-migration/tests/run-tests.sh` (existing suite; no new test — the file is data, and the parser rejects malformed rows)
+
+**Interfaces:**
+
+- Consumes: `om_read_move_list` in `scripts/org-migration/lib.sh:13-25` — a row is `repo<TAB>target`; `#` lines are comments.
+- Produces: a move-list whose target column is the *actual* end state for every repo, so `verify.sh` and the Task 11 Step 5 repoint loop stop reporting the retired five as drift.
+
+- [ ] **Step 1: Edit the header comment and the five rows**
+
+Replace the header comment block (lines 1–6) with:
+
+```text
+# repo<TAB>target-org — reviewed by hand in the PR that added it.
+# Source of truth for transfer.sh; never derived at run time.
+# Rows are alphabetical; order carries no meaning. github-workflows is
+# transferred first and alone via `transfer.sh --only github-workflows`
+# (design Step 3).
+# cleanroom is the one repo that targets nightowlstudiollc.
+# Five repos target twistedmelonman: their smartwatermelon/<name> paths are
+# permanently retired by GitHub (popular-repository namespace retirement,
+# HTTP 422 on transfer and on create). They stay on the user account with
+# working redirects. Support ticket 4729524; assume denial. See
+# docs/STATUS.md "Deferred by decision".
+```
+
+Change these five rows so the target reads `twistedmelonman` (keep the TAB):
+
+```text
+claude-config twistedmelonman
+dotfiles twistedmelonman
+huddle-transcribe twistedmelonman
+personify twistedmelonman
+projectinsomnia twistedmelonman
+```
+
+- [ ] **Step 2: Run the org-migration suite**
+
+Run: `bash /Users/andrewrich/Developer/dev-env/scripts/org-migration/tests/run-tests.sh`
+Expected: all 38 tests pass (the suite uses its own fixture lists; this confirms nothing depends on the real file's contents).
+
+- [ ] **Step 3: Confirm the repoint loop no longer flags the two clones**
+
+Run the read-only form of the Task 11 Step 5 loop:
+
+```bash
+for d in "${HOME}"/Developer/*/.git; do
+  dir="${d%/.git}"
+  url="$(git -C "${dir}" remote get-url origin 2>/dev/null || true)"
+  [[ "${url}" =~ github\.com[:/]twistedmelonman/ ]] || continue
+  repo="${url##*/}"; repo="${repo%.git}"
+  grep -qE "^${repo}[[:space:]]+smartwatermelon$" \
+    /Users/andrewrich/Developer/dev-env/scripts/org-migration/move-list.txt \
+    && echo "DRIFT: ${dir##*/} ${url}"
+done
+```
+
+Expected: no output. (Before the edit it printed `claude-config` and `huddle-transcribe`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/andrewrich/Developer/dev-env add scripts/org-migration/move-list.txt
+git -C /Users/andrewrich/Developer/dev-env commit -m "chore(org-migration): record the five retired paths as staying on twistedmelonman"
+```
+
+---
+
+### Task 2: Migration spec status line (Task 13 Step 3, never done)
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-09-03-org-migration-design.md:3-6`
+
+- [ ] **Step 1: Replace the status paragraph**
+
+Replace lines 3–6 with:
+
+```markdown
+Status: EXECUTED 2026-09-04 as a rename-then-reclaim. 25 of 30 repos
+transferred; five paths permanently retired (see `docs/STATUS.md`). Findings
+and deviations are in dev-env#54's closing comment and dev-env#84. Executes
+items I3 and F4 of `2026-09-01-infrastructure-backlog-design.md`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/andrewrich/Developer/dev-env add docs/superpowers/specs/2026-09-03-org-migration-design.md
+git -C /Users/andrewrich/Developer/dev-env commit -m "docs(org-migration): mark the spec executed"
+```
+
+---
+
+### Task 3: Refresh `docs/STATUS.md`
+
+**Files:**
+
+- Modify: `docs/STATUS.md`
+
+- [ ] **Step 1: Update the header date**
+
+Line 3: `**As of 2026-09-05.**` → `**As of 2026-09-08.**`
+
+- [ ] **Step 2: Update the layer table**
+
+Replace the table rows under "Where the project is" with:
+
+```markdown
+| Layer | State |
+| --- | --- |
+| Foundation (F) | F1, F3, F4 done. F2 open (latent hazard, not urgent). |
+| Identity / billing (I) | I3 done. I0, I1, I2 open. |
+| Fleet (W) | W0 done. W1, W2, W3 open — **critical path**. Design decisions taken 2026-09-08. |
+| Local review (L) | L1 done. L2, L3, L4, L5 open. |
+| Runtime EOL (N) | N1a done. N1b (product repos) open. |
+```
+
+- [ ] **Step 3: Add the three done items under "Done"**
+
+Append after the W0 subsection (before "## Open work, in priority order"):
+
+```markdown
+### Starter set — L1, N1a, F3 (2026-09-02/03)
+
+Executed per `docs/superpowers/plans/2026-09-02-infrastructure-backlog-starter-set.md`
+and previously unrecorded here:
+
+- **L1 — dotfiles config contamination.** Remediation (`git-env-isolation.sh`,
+  9 fixture tests, a known-bad control) had already landed; the starter set
+  removed the `uchg` tripwire on `dotfiles/.git/config`. Verified 2026-09-08:
+  no flag, `core.hooksPath` intact. Follow-up `dotfiles#304` records why the
+  flag is intentionally absent.
+- **N1a — local nvm default and infra-repo CI pins.** `~/.nvm/alias/default`
+  is `lts/krypton` (v24.19.0). `claude-code-workflows-agents#16` merged.
+- **F3 — `GH_TOKEN` precedence guard, cheap tier.** `dotfiles#302` merged:
+  the wrapper fails closed when `GH_TOKEN` resolves to a login other than the
+  one the repo owner maps to. Follow-up `dotfiles#303` (cache the lookup).
+
+### Migration cleanup (Steps 5–7) and the other two machines
+
+Org secret set (visibility `ALL`), `ralph-burndown` secret removed,
+`claude-code-login` and `smartwatermelon.github.io` deleted, #85 filed, #54
+closed. Runbook Part D verified on TILSIT and MIMOLETTE 2026-09-08 (both
+authenticate as `twistedmelonman`); MIMOLETTE's dotfiles clone was 15 commits
+behind and was fast-forwarded. The temporary login alias is now removable
+(migration plan Task 12).
+```
+
+- [ ] **Step 4: Rewrite "Open work, in priority order"**
+
+Replace the whole section body (from `### Blocking nothing, but on the critical path` through the end of `### Filed this session`) with:
+
+```markdown
+### Critical path: W1 → W2 → W3
+
+Decisions taken 2026-09-08 (Andrew) that unblock W1 — see
+`docs/superpowers/plans/2026-09-08-backlog-remainder-roadmap.md`:
+
+- **No judgment reviewer stays in CI.** `standards-check.yml` replaces
+  `claude-blocking-review.yml` outright; local hooks are the only judgment
+  pass. `claude-assistant.yml` is out of scope and keeps its token.
+- **`nightowl-restore-blocking-review.sh` is retired with W3.**
+
+W2 pilots, re-picked from repos with no enforcement today: `repo-template`,
+`pr-review`, `claude-code-workflows-agents`, `nightowlstudiollc/.github`.
+`scripts` is not a pilot (see #85).
+
+### Runs in parallel with W
+
+- **I0** — `CLAUDE_CONFIG_DIR` billing-verification script. Deliverable is a
+  script Andrew runs on the company machine.
+- **F2** — owner-aware `git-identity.sh`. Latent hazard only; do after I0.
+- **N1b** — product-repo Node bumps (`tensegrity`, `kebab-tax`,
+  `Gmail-MCP-Server`, `reliquarist`). Confirm each job reaches its Node
+  step before and after.
+- **L2 → L3, L4, L5** — deploy/edit separation, the false-OK pair
+  (claude-config#439, #451), doc hygiene, small unfiled items.
+- **#89** — add `claude-blocking-review.yml` + exemplar protection to
+  `smartwatermelon/.github` only; the other three stay ungated by decision.
+- **#90** — evaluate org rulesets on one test repo against a known-bad PR.
+- **#85** — full-history secret audit of `scripts`, then stop and report.
+- **#94** — Netlify publish verification for six sites (needs the Netlify
+  dashboard as the inventory of record).
+
+### Filed 2026-09-05
+
+- **#84** — three conditions the org-migration design's failure table does
+  not cover.
+```
+
+- [ ] **Step 5: Update "Deferred by decision"**
+
+Replace the `Runbook Part D` row with:
+
+```markdown
+| Runbook Part D on TILSIT and MIMOLETTE | **Done 2026-09-08.** Alias removal (migration plan Task 12) is unblocked. |
+```
+
+Replace the `Five retired repo paths` row with:
+
+```markdown
+| Five retired repo paths | **Support ticket 4729524.** Closed by GitHub 2026-09-04 as self-service-only; reopened after the org's Team upgrade; status requested 2026-09-08, no staff reply. Assume denial. The move-list now records `twistedmelonman` as their end state. |
+```
+
+- [ ] **Step 6: Run markdown lint if configured, then commit**
+
+Run: `ls /Users/andrewrich/Developer/dev-env/.markdownlint* 2>/dev/null && markdownlint /Users/andrewrich/Developer/dev-env/docs/STATUS.md || true`
+
+```bash
+git -C /Users/andrewrich/Developer/dev-env add docs/STATUS.md docs/superpowers/plans/2026-09-08-backlog-remainder-roadmap.md
+git -C /Users/andrewrich/Developer/dev-env commit -m "docs(status): record L1/N1a/F3, migration cleanup, and the 2026-09-08 W1 decisions"
+```
+
+Then push the branch and open the PR (title: `docs: refresh status for 2026-09-08 and record the W1 decisions`). Surface repo, PR number, URL.
+
+---
+
+### Task 4: Remove the temporary login alias (dotfiles)
+
+**Files:**
+
+- Modify: `~/Developer/dotfiles/bash/gh-wrapper.sh` (alias block at lines 187–191 and `_gh_wrapper_logins_equal`; header comment)
+- Modify: `~/Developer/dotfiles/bash/tests/test-gh-wrapper-identity.sh`, `~/Developer/dotfiles/bash/tests/test-gh-wrapper-gh-token-precedence.sh`
+
+**Gate:** satisfied 2026-09-08 (see "Live state measured" above).
+
+This task is fully specified as **Task 12** in
+`docs/superpowers/plans/2026-09-03-org-migration.md` (lines 1947–1991):
+tests first, observe the two new cases FAIL, remove the alias, observe PASS,
+shellcheck, full dotfiles suite, branch
+`claude/chore-gh-wrapper-drop-alias-<session>`, commit subject
+`chore(gh-wrapper): remove the twistedmelonman=smartwatermelon alias`. Follow
+it verbatim. Two additions:
+
+- [ ] **Step A: Re-verify the gate from the executing machine before editing**
+
+```bash
+for h in tilsit.local mimolette.local; do
+  printf '%s: ' "$h"
+  ssh -o ConnectTimeout=6 -o BatchMode=yes "$h" 'env -u GH_TOKEN gh api user --jq .login'
+done
+env -u GH_TOKEN gh api user --jq .login
+```
+
+Expected: `twistedmelonman` three times. If any machine prints anything else or is unreachable, stop and report; do not remove the alias.
+
+- [ ] **Step B: After the PR merges, pull dotfiles on all three machines**
+
+```bash
+git -C /Users/andrewrich/Developer/dotfiles pull --ff-only
+for h in tilsit.local mimolette.local; do
+  ssh -o ConnectTimeout=6 -o BatchMode=yes "$h" '/opt/homebrew/bin/bash -lc "git -C ~/Developer/dotfiles pull --ff-only && cd ~/Developer/dotfiles && gh pr list --limit 1 >/dev/null && echo ok"'
+done
+```
+
+Expected: `ok` from both. Use `/opt/homebrew/bin/bash` explicitly: a bare `ssh host 'bash -lc'` resolves `/bin/bash` 3.2 and the wrapper's `${owner,,}` fails with "bad substitution".
+
+---
+
+## Roadmap for the rest of the backlog
+
+Each stage below gets its own plan document when it starts. Stages within a
+row run in parallel; rows run in order only where an arrow says so.
+
+| Order | Stage | Needs from Andrew |
+| --- | --- | --- |
+| 1 | Tasks 1–4 above (two PRs: dev-env, dotfiles) | merge locks |
+| 2 | **W1 plan + build** `standards-check.yml` in `github-workflows`. Reference: `personify`'s `validate` workflow; fold in `zizmor.yml` propagation and a Node-line assertion. | merge lock |
+| 2 (parallel) | **I0** billing script; **#85** history audit (report only); **#89** `.github` gate; **N1b** product-repo Node bumps; **L4** doc hygiene; **L5** small items | I0: run it on the company machine. #85: yes/no on rewrite, then on flip. Merge locks. |
+| 3 | **W2 pilots** (4 repos above), then fleet via `bulk-install-claude-review.sh` pattern; `repo-template` pin correction and self-linting in the same pass; `scripts` caller-stub conversion | merge locks; pilot verdict is measured (fast, quiet, catches a known-bad diff), not asked |
+| 3 (parallel) | **#90** ruleset evaluation on one test repo; **L2 → L3**; **#94** Netlify | #94 may need the Netlify dashboard; **F2** after I0 |
+| 4 | **W3** flip required checks per repo (add `standards-check`, then remove `claude-review / run-review`, never zero), retire the reviewer, cut the major, retire `nightowl-restore-blocking-review.sh`, update `repo-template`, drop review-only tokens | merge locks; a final go before the major tag |
+| 5 | **I1 → I2** account-switching module, company-machine setup | I2 is manual on the company machine |
+
+Interruptions are reduced to: merge locks, the four yes/no gates named in the
+column above, and anything that turns out to need the Netlify or GitHub web
+UI.

--- a/docs/superpowers/plans/2026-09-08-backlog-remainder-roadmap.md
+++ b/docs/superpowers/plans/2026-09-08-backlog-remainder-roadmap.md
@@ -204,7 +204,7 @@ and previously unrecorded here:
 Org secret set (visibility `ALL`), `ralph-burndown` secret removed,
 `claude-code-login` and `smartwatermelon.github.io` deleted, #85 filed, #54
 closed. Runbook Part D verified on TILSIT and MIMOLETTE 2026-09-08 (both
-authenticate as `twistedmelonman`); MIMOLETTE's dotfiles clone was 15 commits
+authenticate as `twistedmelonman`); MIMOLETTE's dotfiles clone was 35 commits
 behind and was fast-forwarded. The temporary login alias is now removable
 (migration plan Task 12).
 ```

--- a/docs/superpowers/plans/2026-09-08-backlog-remainder-roadmap.md
+++ b/docs/superpowers/plans/2026-09-08-backlog-remainder-roadmap.md
@@ -51,7 +51,7 @@ the two open follow-ups from W0. They are inputs to the roadmap below.
 | L1 done | `dotfiles/.git/config` carries no `uchg` flag; `core.hooksPath` = `~/.config/git/hooks`; starter-set Task 4 |
 | N1a done | `~/.nvm/alias/default` = `lts/krypton`; `which node` → v24.19.0; `claude-code-workflows-agents#16` merged |
 | F3 done | `dotfiles#302` MERGED (fail closed when `GH_TOKEN` overrides the resolved identity) |
-| Support ticket 4729524 | closed by GitHub 2026-09-04 as self-service-only; reopened same day after the Team upgrade; status ping sent 2026-09-08. No staff reply. Assume denial. |
+| Support ticket 4729524 | closed by GitHub 2026-09-04 as self-service-only; reopened same day after the Team upgrade; status ping sent 2026-09-08. No staff reply. Andrew is not giving up on the paths; the move-list carries an interim shim. |
 | Task 11 Step 5 loop flags `claude-config`, `huddle-transcribe` | both are retired paths; `twistedmelonman` is their correct remote. The move-list still says `smartwatermelon`, so the loop and `verify.sh` treat them as drift. |
 
 ---
@@ -79,11 +79,12 @@ Replace the header comment block (lines 1–6) with:
 # transferred first and alone via `transfer.sh --only github-workflows`
 # (design Step 3).
 # cleanroom is the one repo that targets nightowlstudiollc.
-# Five repos target twistedmelonman: their smartwatermelon/<name> paths are
-# permanently retired by GitHub (popular-repository namespace retirement,
-# HTTP 422 on transfer and on create). They stay on the user account with
-# working redirects. Support ticket 4729524; assume denial. See
-# docs/STATUS.md "Deferred by decision".
+# Five repos target twistedmelonman as an INTERIM shim: their
+# smartwatermelon/<name> paths are retired by GitHub (popular-repository
+# namespace retirement, HTTP 422 on transfer and on create). They stay on
+# the user account with working redirects while support ticket 4729524 is
+# open. If GitHub releases the paths, flip these five back to
+# smartwatermelon and re-run transfer.sh. See docs/STATUS.md.
 ```
 
 Change these five rows so the target reads `twistedmelonman` (keep the TAB):
@@ -140,7 +141,7 @@ Replace lines 3–6 with:
 
 ```markdown
 Status: EXECUTED 2026-09-04 as a rename-then-reclaim. 25 of 30 repos
-transferred; five paths permanently retired (see `docs/STATUS.md`). Findings
+transferred; five paths retired pending support ticket 4729524 (see `docs/STATUS.md`). Findings
 and deviations are in dev-env#54's closing comment and dev-env#84. Executes
 items I3 and F4 of `2026-09-01-infrastructure-backlog-design.md`.
 ```
@@ -262,7 +263,7 @@ Replace the `Runbook Part D` row with:
 Replace the `Five retired repo paths` row with:
 
 ```markdown
-| Five retired repo paths | **Support ticket 4729524.** Closed by GitHub 2026-09-04 as self-service-only; reopened after the org's Team upgrade; status requested 2026-09-08, no staff reply. Assume denial. The move-list now records `twistedmelonman` as their end state. |
+| Five retired repo paths | **Support ticket 4729524.** Closed by GitHub 2026-09-04 as self-service-only; reopened after the org's Team upgrade; status requested 2026-09-08, no staff reply. **Not given up on.** The move-list records `twistedmelonman` as an interim shim; flip back and re-run `transfer.sh` if the paths are released. |
 ```
 
 - [ ] **Step 6: Run markdown lint if configured, then commit**

--- a/docs/superpowers/plans/2026-09-08-w1-standards-check.md
+++ b/docs/superpowers/plans/2026-09-08-w1-standards-check.md
@@ -1,0 +1,836 @@
+# W1: `standards-check.yml` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A deterministic, secret-free reusable workflow in
+`smartwatermelon/github-workflows` that runs shellcheck, yamllint, actionlint,
+zizmor, markdownlint, and a Node-EOL floor check, so it can replace
+`claude-blocking-review.yml` as the fleet's required check (W2, W3).
+
+**Architecture:** One bash script, `standards/run-standards.sh`, does all the
+work and is testable locally against known-bad fixtures. The reusable
+workflow `.github/workflows/standards-check.yml` only installs pinned tools,
+fetches canonical configs for repos that carry none, and runs the script. A
+self-applying caller dogfoods it on `github-workflows`' own PRs. The workflow
+gets its own tag namespace (`standards-check-v1`), like
+`dependabot-auto-merge-v2`, because git tags are repo-scoped.
+
+**Tech Stack:** GitHub Actions on `ubuntu-latest`, bash 5, shellcheck 0.11.0,
+actionlint 1.7.12, zizmor 1.30.0, yamllint 1.38.0, markdownlint-cli2 0.23.2.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-infrastructure-backlog-design.md`
+("W1 — Build `standards-check.yml`", "Folded into the same pass", "Runtime EOL
+layer → Feeds W1"), `smartwatermelon/github-workflows#154` (Phase 1), and the
+decisions recorded in `2026-09-08-backlog-remainder-roadmap.md`. Research
+inputs: `.superpowers/sdd/2026-09-08-backlog-remainder-roadmap/w1-research.md`
+(git-ignored scratch; the facts it established are restated here).
+
+## Global Constraints
+
+- Work happens in `/Users/andrewrich/Developer/github-workflows`. Never commit
+  on `main`; branch `claude/feat-standards-check-<session>`.
+- Every third-party `uses:` is SHA-pinned with a `# vX.Y.Z` comment
+  (`zizmor.yml` policy: `"*": hash-pin`). First-party refs may float.
+- Every tool binary is version-pinned and, where a checksum is published,
+  checksum-verified before use. No marketplace actions for the linters.
+- No secrets. The only token is the default `GITHUB_TOKEN`, `contents: read`.
+- `shellcheck -S info` clean on every shell file added; no
+  `# shellcheck disable`; never `((var++))`.
+- Every check in the script is validated against a known-bad fixture that is
+  observed FAILING before the check is trusted.
+- Text files end with a newline. Markdown passes markdownlint with the
+  canonical config below.
+
+## Design rulings (2026-09-08)
+
+| Ruling | Why | Cost if wrong |
+| --- | --- | --- |
+| **Lint-only. The workflow does not run a repo's tests.** | Runners are heterogeneous (pytest, vitest, jest, `node --test`, bats, Makefile, none). Repos that have a test workflow keep it and W3 adds it to required checks alongside `standards-check`, the way `personify` already requires `validate`. | Repos with no test workflow stay without a test gate — same as today. |
+| **Own tag namespace `standards-check-v1`.** | Tags are repo-scoped; `v3` belongs to `claude-blocking-review.yml`. Same pattern as `dependabot-auto-merge-v2`. | None expected. |
+| **Script-first: `standards/run-standards.sh` does the work; the workflow is a thin installer.** | Local testability with known-bad fixtures; a human can run the same check before pushing. | Slightly more files. |
+| **Tools by checksummed release tarball (shellcheck, actionlint, zizmor), `pipx` pin (yamllint), `npx` pin (markdownlint-cli2).** | No first-party actions exist for these; the fleet already uses the checksummed-tarball pattern for shellcheck in two repos. | Version bumps are manual PRs to `github-workflows` (Dependabot does not track them). |
+| **Config precedence: repo-root config if present, else the canonical file from `github-workflows/standards/` at the *called workflow's* SHA (`github.job_workflow_sha`).** | Lets repos opt into stricter/looser rules while giving every repo a working default without W2 having to copy three files. `zizmor.yml` is still propagated in W2 because local pre-commit needs it. | A repo's local pre-commit and CI could disagree until the repo carries its own config. |
+| **Per-linter boolean inputs, all default `true`; `node_floor` default `"22"`.** | W2 pilots will find repos with lint debt; a toggle keeps rollout unblocked while debt is paid. Node 20 is EOL; 22 is the lowest supported line. | A repo could silently disable a linter — visible in its caller stub, which is reviewed. |
+| **shellcheck severity `info`, matching the local standard.** | The local hook uses `-S info`; CI should not be looser. | More findings on first rollout; pilots measure. |
+| **No doc-only or Dependabot skip.** | Linting is seconds and deterministic; the skips existed to save LLM cost. | None. |
+| **Check name `standards-check / run-standards-check`.** | Same `{caller job} / {inner job}` mechanism as `claude-review / run-review`. | Branch protection must use this exact string (W3). |
+
+---
+
+### Task 1: Canonical configs and the Node-floor checker
+
+**Files:**
+
+- Create: `standards/markdownlint.json`
+- Create: `standards/yamllint.yml`
+- Create: `standards/check-node-floor.sh`
+- Create: `tests/test-check-node-floor.sh`
+- Create: `tests/run-tests.sh`
+
+**Interfaces:**
+
+- Produces: `standards/check-node-floor.sh <repo-dir> <floor-major>` → exit 0 when no Node pin below the floor is found, exit 1 and one `::error::` line per offending pin otherwise. Task 2's script calls it.
+- Produces: `tests/run-tests.sh` runs every `tests/test-*.sh` and exits nonzero if any fails. Task 2 adds to it.
+
+- [ ] **Step 1: Write the canonical configs**
+
+`standards/markdownlint.json` — identical to `~/.config/markdownlint-cli/.markdownlint.json`:
+
+```json
+{
+  "default": true,
+  "MD013": false,
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD029": false,
+  "MD033": false,
+  "MD036": false,
+  "MD040": false,
+  "MD046": false,
+  "MD060": false
+}
+```
+
+`standards/yamllint.yml` — identical to `~/.config/yamllint/config`:
+
+```yaml
+---
+# Canonical yamllint config for standards-check.yml. Mirrors
+# ~/.config/yamllint/config in dotfiles; keep them in sync.
+extends: relaxed
+
+rules:
+  line-length:
+    max: 120
+```
+
+- [ ] **Step 2: Write the failing test for the Node-floor checker**
+
+`tests/run-tests.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Runs every tests/test-*.sh; exits nonzero if any fails.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+failed=0
+for t in "${here}"/test-*.sh; do
+  echo "== ${t##*/}"
+  if bash "${t}"; then
+    echo "PASS ${t##*/}"
+  else
+    echo "FAIL ${t##*/}"
+    failed=$((failed + 1))
+  fi
+done
+echo "${failed} test file(s) failed"
+[[ "${failed}" -eq 0 ]]
+```
+
+`tests/test-check-node-floor.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Known-bad validation for standards/check-node-floor.sh. Each fixture is a
+# throwaway directory; the control case proves the checker can fail.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+checker="${here}/../standards/check-node-floor.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+pass=0; fail=0
+_ok() { echo "  ok   $1"; pass=$((pass + 1)); }
+_bad() { echo "  FAIL $1"; fail=$((fail + 1)); }
+
+# Fixture 1: workflow pins node 20 -> must fail
+mkdir -p "${tmp}/f1/.github/workflows"
+cat >"${tmp}/f1/.github/workflows/ci.yml" <<'EOF'
+jobs:
+  build:
+    steps:
+      - uses: actions/setup-node@abc
+        with:
+          node-version: 20
+EOF
+if bash "${checker}" "${tmp}/f1" 22 >/dev/null 2>&1; then _bad "workflow node-version 20 accepted"; else _ok "workflow node-version 20 rejected"; fi
+
+# Fixture 2: .nvmrc 18.20.4 -> must fail
+mkdir -p "${tmp}/f2"; echo "18.20.4" >"${tmp}/f2/.nvmrc"
+if bash "${checker}" "${tmp}/f2" 22 >/dev/null 2>&1; then _bad ".nvmrc 18 accepted"; else _ok ".nvmrc 18 rejected"; fi
+
+# Fixture 3: package.json engines floor admits 14 -> must fail
+mkdir -p "${tmp}/f3"; echo '{"engines":{"node":">=14.0.0"}}' >"${tmp}/f3/package.json"
+if bash "${checker}" "${tmp}/f3" 22 >/dev/null 2>&1; then _bad "engines >=14 accepted"; else _ok "engines >=14 rejected"; fi
+
+# Fixture 4: everything at or above the floor -> must pass
+mkdir -p "${tmp}/f4/.github/workflows"
+printf 'jobs:\n  b:\n    steps:\n      - with:\n          node-version: "24"\n' >"${tmp}/f4/.github/workflows/ci.yml"
+echo "lts/krypton" >"${tmp}/f4/.nvmrc"
+echo '{"engines":{"node":">=22"}}' >"${tmp}/f4/package.json"
+if bash "${checker}" "${tmp}/f4" 22 >/dev/null 2>&1; then _ok "conformant repo passes"; else _bad "conformant repo rejected"; fi
+
+# Fixture 5: no Node anywhere -> must pass
+mkdir -p "${tmp}/f5"; echo "hi" >"${tmp}/f5/README.md"
+if bash "${checker}" "${tmp}/f5" 22 >/dev/null 2>&1; then _ok "repo without Node passes"; else _bad "repo without Node rejected"; fi
+
+# Fixture 6: node-version-file indirection to a bad .nvmrc -> must fail
+mkdir -p "${tmp}/f6/.github/workflows"; echo "20.19.4" >"${tmp}/f6/.nvmrc"
+printf 'jobs:\n  b:\n    steps:\n      - with:\n          node-version-file: .nvmrc\n' >"${tmp}/f6/.github/workflows/ci.yml"
+if bash "${checker}" "${tmp}/f6" 22 >/dev/null 2>&1; then _bad "node-version-file -> 20 accepted"; else _ok "node-version-file -> 20 rejected"; fi
+
+echo "${pass} passed, ${fail} failed"
+[[ "${fail}" -eq 0 ]]
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `bash /Users/andrewrich/Developer/github-workflows/tests/test-check-node-floor.sh`
+Expected: script errors because `standards/check-node-floor.sh` does not exist (every "rejected" case reports FAIL-by-absence is not acceptable — the checker must exist and fail *for the right reason*, so proceed to Step 4 and re-run).
+
+- [ ] **Step 4: Write the checker**
+
+`standards/check-node-floor.sh`:
+
+```bash
+#!/usr/bin/env bash
+# check-node-floor.sh <repo-dir> <floor-major>
+#
+# Fails (exit 1) if any Node.js version pin in the repo names a major below
+# <floor-major>. Sources scanned:
+#   - .github/workflows/*.yml|*.yaml : `node-version:` literals and
+#     `node-version-file:` indirections
+#   - .nvmrc, .node-version           : bare versions ("20", "20.19.4", "v18")
+#   - package.json                    : engines.node lower bound (">=14.0.0")
+# Named aliases (lts/*, node, latest, current) are accepted: they float and
+# are never below the floor. Expressions (${{ ... }}) are skipped with a
+# notice because they cannot be resolved statically.
+set -euo pipefail
+
+repo="${1:?usage: check-node-floor.sh <repo-dir> <floor-major>}"
+floor="${2:?usage: check-node-floor.sh <repo-dir> <floor-major>}"
+[[ "${floor}" =~ ^[0-9]+$ ]] || { echo "::error::floor must be an integer major, got '${floor}'"; exit 2; }
+
+errors=0
+
+# _major <version-string> -> prints the major, or nothing for aliases/unparseable.
+_major() {
+  local v="${1}"
+  v="${v#v}"; v="${v%%.*}"
+  [[ "${v}" =~ ^[0-9]+$ ]] && printf '%s' "${v}"
+}
+
+# _check <major-or-empty> <where>
+_check() {
+  local major="${1}" where="${2}"
+  [[ -z "${major}" ]] && return 0
+  if (( major < floor )); then
+    echo "::error::${where}: Node ${major} is below the supported floor (${floor})"
+    errors=$((errors + 1))
+  fi
+}
+
+# _version_from_file <path> -> first non-empty, non-comment line, trimmed
+_version_from_file() {
+  grep -vE '^\s*(#|$)' "${1}" | head -1 | tr -d '[:space:]'
+}
+
+for f in "${repo}/.nvmrc" "${repo}/.node-version"; do
+  [[ -f "${f}" ]] || continue
+  raw="$(_version_from_file "${f}")"
+  _check "$(_major "${raw}")" "${f#"${repo}"/}: ${raw}"
+done
+
+if [[ -f "${repo}/package.json" ]] && command -v jq >/dev/null; then
+  eng="$(jq -r '.engines.node // empty' "${repo}/package.json" 2>/dev/null || true)"
+  if [[ -n "${eng}" ]]; then
+    # Lower bound: first numeric token after an optional >= / ^ / ~ prefix.
+    low="$(printf '%s' "${eng}" | grep -oE '[0-9]+(\.[0-9]+)*' | head -1 || true)"
+    _check "$(_major "${low}")" "package.json engines.node: ${eng}"
+  fi
+fi
+
+shopt -s nullglob
+for wf in "${repo}"/.github/workflows/*.yml "${repo}"/.github/workflows/*.yaml; do
+  rel="${wf#"${repo}"/}"
+  while IFS= read -r line; do
+    val="$(printf '%s' "${line}" | sed -E 's/.*node-version:[[:space:]]*//; s/[[:space:]]*#.*$//; s/^["'"'"']//; s/["'"'"']$//')"
+    if [[ "${val}" == *'${{'* ]]; then
+      echo "::notice::${rel}: node-version is an expression (${val}); not checked"
+      continue
+    fi
+    _check "$(_major "${val}")" "${rel}: node-version: ${val}"
+  done < <(grep -E '^\s*node-version:' "${wf}" || true)
+  while IFS= read -r line; do
+    vf="$(printf '%s' "${line}" | sed -E 's/.*node-version-file:[[:space:]]*//; s/[[:space:]]*#.*$//; s/^["'"'"']//; s/["'"'"']$//')"
+    if [[ -f "${repo}/${vf}" ]]; then
+      raw="$(_version_from_file "${repo}/${vf}")"
+      _check "$(_major "${raw}")" "${rel}: node-version-file ${vf} -> ${raw}"
+    fi
+  done < <(grep -E '^\s*node-version-file:' "${wf}" || true)
+done
+
+if (( errors > 0 )); then
+  echo "::error::${errors} Node pin(s) below floor ${floor}. Node 20 reached EOL 2026-04-30."
+  exit 1
+fi
+echo "Node floor ${floor}: OK"
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `bash /Users/andrewrich/Developer/github-workflows/tests/test-check-node-floor.sh`
+Expected: `6 passed, 0 failed`.
+
+Run: `shellcheck -S info /Users/andrewrich/Developer/github-workflows/standards/check-node-floor.sh /Users/andrewrich/Developer/github-workflows/tests/test-check-node-floor.sh /Users/andrewrich/Developer/github-workflows/tests/run-tests.sh`
+Expected: silent.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/andrewrich/Developer/github-workflows add standards/markdownlint.json standards/yamllint.yml standards/check-node-floor.sh tests/test-check-node-floor.sh tests/run-tests.sh
+git -C /Users/andrewrich/Developer/github-workflows commit -m "feat(standards): canonical lint configs and a Node-floor checker"
+```
+
+---
+
+### Task 2: `standards/run-standards.sh`
+
+**Files:**
+
+- Create: `standards/run-standards.sh`
+- Create: `tests/test-run-standards.sh`
+
+**Interfaces:**
+
+- Consumes: `standards/check-node-floor.sh` (Task 1).
+- Produces: `standards/run-standards.sh [--repo DIR] [--config-dir DIR] [--skip a,b,c] [--node-floor N]` → exit 0 when every enabled linter is clean, exit 1 otherwise; prints one `== <linter>` header per linter and `::error::` lines for findings. Linter names: `shellcheck`, `yamllint`, `actionlint`, `zizmor`, `markdownlint`, `node-floor`. Task 3's workflow calls it exactly this way.
+- Requires on `PATH`: `shellcheck`, `yamllint`, `actionlint`, `zizmor`, `markdownlint-cli2`, `jq`, `git`.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/test-run-standards.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Known-bad validation for standards/run-standards.sh: one fixture per
+# linter that MUST fail, one clean fixture that MUST pass, and a --skip case
+# proving the toggle really disables a linter. Requires the five tools on
+# PATH (brew install shellcheck yamllint actionlint zizmor markdownlint-cli2).
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+runner="${here}/../standards/run-standards.sh"
+cfg="${here}/../standards"
+for tool in shellcheck yamllint actionlint zizmor markdownlint-cli2 jq; do
+  command -v "${tool}" >/dev/null || { echo "SKIP: ${tool} not on PATH"; exit 0; }
+done
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+pass=0; fail=0
+_ok() { echo "  ok   $1"; pass=$((pass + 1)); }
+_bad() { echo "  FAIL $1"; fail=$((fail + 1)); }
+_mk() { mkdir -p "${tmp}/$1"; git -C "${tmp}/$1" init -q; }
+_expect_fail() { # name dir
+  if bash "${runner}" --repo "${tmp}/$2" --config-dir "${cfg}" >"${tmp}/$2.log" 2>&1; then _bad "$1 (accepted; see ${tmp}/$2.log)"; else _ok "$1"; fi
+}
+_expect_pass() {
+  if bash "${runner}" --repo "${tmp}/$2" --config-dir "${cfg}" >"${tmp}/$2.log" 2>&1; then _ok "$1"; else _bad "$1 (rejected; see ${tmp}/$2.log)"; cat "${tmp}/$2.log"; fi
+}
+
+_mk bad-sh; printf '#!/usr/bin/env bash\necho $1\n' >"${tmp}/bad-sh/x.sh"; git -C "${tmp}/bad-sh" add -A
+_expect_fail "shellcheck: unquoted \$1 (SC2086) rejected" bad-sh
+
+_mk bad-yaml; printf 'a: 1\n  b: 2\n' >"${tmp}/bad-yaml/x.yml"; git -C "${tmp}/bad-yaml" add -A
+_expect_fail "yamllint: bad indentation rejected" bad-yaml
+
+_mk bad-action; mkdir -p "${tmp}/bad-action/.github/workflows"
+printf 'on: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n        uses: actions/checkout@v7\n' >"${tmp}/bad-action/.github/workflows/ci.yml"
+git -C "${tmp}/bad-action" add -A
+_expect_fail "actionlint: run+uses in one step rejected" bad-action
+
+_mk bad-zizmor; mkdir -p "${tmp}/bad-zizmor/.github/workflows"
+printf 'on: pull_request_target\npermissions: write-all\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v7\n        with:\n          ref: ${{ github.event.pull_request.head.ref }}\n' >"${tmp}/bad-zizmor/.github/workflows/ci.yml"
+git -C "${tmp}/bad-zizmor" add -A
+_expect_fail "zizmor: pwn-request / unpinned third-party rejected" bad-zizmor
+
+_mk bad-md; printf '#Bad heading\n\n\n\nx\n' >"${tmp}/bad-md/README.md"; git -C "${tmp}/bad-md" add -A
+_expect_fail "markdownlint: MD018/MD012 rejected" bad-md
+
+_mk bad-node; echo "20" >"${tmp}/bad-node/.nvmrc"; git -C "${tmp}/bad-node" add -A
+_expect_fail "node-floor: .nvmrc 20 rejected" bad-node
+
+_mk clean; mkdir -p "${tmp}/clean/.github/workflows"
+printf '#!/usr/bin/env bash\nset -euo pipefail\necho "${1:-}"\n' >"${tmp}/clean/ok.sh"
+printf '# Title\n\nBody.\n' >"${tmp}/clean/README.md"
+printf 'key: value\n' >"${tmp}/clean/x.yml"
+printf 'on: push\npermissions:\n  contents: read\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n' >"${tmp}/clean/.github/workflows/ci.yml"
+echo "lts/krypton" >"${tmp}/clean/.nvmrc"
+git -C "${tmp}/clean" add -A
+_expect_pass "clean repo passes every linter" clean
+
+if bash "${runner}" --repo "${tmp}/bad-sh" --config-dir "${cfg}" --skip shellcheck >/dev/null 2>&1; then _ok "--skip shellcheck disables the linter"; else _bad "--skip shellcheck did not disable it"; fi
+
+_mk empty; git -C "${tmp}/empty" add -A
+_expect_pass "empty repo passes (nothing to lint is not a failure)" empty
+
+echo "${pass} passed, ${fail} failed"
+[[ "${fail}" -eq 0 ]]
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `bash /Users/andrewrich/Developer/github-workflows/tests/test-run-standards.sh`
+Expected: every case FAILs or errors because the runner does not exist. If it prints `SKIP: <tool> not on PATH`, install the tool with Homebrew first; the tools are required for this task.
+
+- [ ] **Step 3: Write the runner**
+
+`standards/run-standards.sh`:
+
+```bash
+#!/usr/bin/env bash
+# run-standards.sh — the deterministic standards check.
+#
+#   run-standards.sh [--repo DIR] [--config-dir DIR] [--skip a,b,c] [--node-floor N]
+#
+# Runs shellcheck, yamllint, actionlint, zizmor, markdownlint, and the
+# Node-floor check over the tracked files of DIR (default: cwd). Exit 0 only
+# when every enabled linter is clean. A linter with nothing to lint passes
+# with a notice — absence of files is not a failure.
+#
+# Config precedence, per linter: a config at the repo root wins; otherwise
+# the canonical file under --config-dir (github-workflows/standards/) is
+# used. zizmor's canonical config is ../zizmor.yml relative to --config-dir.
+#
+# Same script runs in CI (standards-check.yml) and locally.
+set -euo pipefail
+
+repo="$(pwd)"
+config_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+skip=""
+node_floor="22"
+while (($# > 0)); do
+  case "$1" in
+    --repo) repo="$2"; shift 2 ;;
+    --config-dir) config_dir="$2"; shift 2 ;;
+    --skip) skip="$2"; shift 2 ;;
+    --node-floor) node_floor="$2"; shift 2 ;;
+    *) echo "::error::unknown argument: $1"; exit 2 ;;
+  esac
+done
+repo="$(cd "${repo}" && pwd)"
+config_dir="$(cd "${config_dir}" && pwd)"
+
+failures=0
+_skipped() { [[ ",${skip}," == *",$1,"* ]]; }
+_header() { echo; echo "== $1"; }
+_fail() { echo "::error::$1 found problems"; failures=$((failures + 1)); }
+_tracked() { git -C "${repo}" ls-files -z --cached --others --exclude-standard; }
+
+# shellcheck: *.sh, *.bash, and files whose shebang is a bourne-family shell.
+if _skipped shellcheck; then echo "== shellcheck: skipped by input"; else
+  _header shellcheck
+  files=()
+  while IFS= read -r -d '' f; do
+    case "${f}" in
+      *.sh|*.bash) files+=("${f}") ;;
+      *) [[ -f "${repo}/${f}" ]] && head -c 64 "${repo}/${f}" 2>/dev/null | head -1 | grep -qE '^#!.*\b(ba)?sh\b' && files+=("${f}") ;;
+    esac
+  done < <(_tracked)
+  if ((${#files[@]} == 0)); then echo "::notice::no shell files"; else
+    (cd "${repo}" && shellcheck -S info "${files[@]}") || _fail shellcheck
+  fi
+fi
+
+# yamllint: *.yml, *.yaml
+if _skipped yamllint; then echo "== yamllint: skipped by input"; else
+  _header yamllint
+  files=()
+  while IFS= read -r -d '' f; do case "${f}" in *.yml|*.yaml) files+=("${f}") ;; esac; done < <(_tracked)
+  if ((${#files[@]} == 0)); then echo "::notice::no YAML files"; else
+    cfg=""
+    for c in .yamllint .yamllint.yml .yamllint.yaml; do [[ -f "${repo}/${c}" ]] && { cfg="${repo}/${c}"; break; }; done
+    [[ -n "${cfg}" ]] || cfg="${config_dir}/yamllint.yml"
+    (cd "${repo}" && yamllint -c "${cfg}" -f parsable "${files[@]}") || _fail yamllint
+  fi
+fi
+
+# actionlint: .github/workflows only; it finds them itself.
+if _skipped actionlint; then echo "== actionlint: skipped by input"; else
+  _header actionlint
+  if compgen -G "${repo}/.github/workflows/*.y*ml" >/dev/null; then
+    (cd "${repo}" && actionlint -shellcheck= -pyflakes=) || _fail actionlint
+  else echo "::notice::no workflows"; fi
+fi
+
+# zizmor: repo-root zizmor.yml, else the canonical policy one level above config-dir.
+if _skipped zizmor; then echo "== zizmor: skipped by input"; else
+  _header zizmor
+  if compgen -G "${repo}/.github/workflows/*.y*ml" >/dev/null; then
+    cfg="${repo}/zizmor.yml"; [[ -f "${cfg}" ]] || cfg="${config_dir}/../zizmor.yml"
+    (cd "${repo}" && zizmor --config "${cfg}" --min-severity low --no-online-audits .) || _fail zizmor
+  else echo "::notice::no workflows"; fi
+fi
+
+# markdownlint: *.md via markdownlint-cli2; repo config wins, else canonical.
+if _skipped markdownlint; then echo "== markdownlint: skipped by input"; else
+  _header markdownlint
+  files=()
+  while IFS= read -r -d '' f; do case "${f}" in *.md) files+=("${f}") ;; esac; done < <(_tracked)
+  if ((${#files[@]} == 0)); then echo "::notice::no Markdown files"; else
+    cfg=""
+    for c in .markdownlint-cli2.jsonc .markdownlint-cli2.yaml .markdownlint-cli2.cjs .markdownlint.jsonc .markdownlint.json .markdownlint.yaml .markdownlint.yml .markdownlintrc; do
+      [[ -f "${repo}/${c}" ]] && { cfg="${repo}/${c}"; break; }
+    done
+    [[ -n "${cfg}" ]] || cfg="${config_dir}/markdownlint.json"
+    (cd "${repo}" && markdownlint-cli2 --config "${cfg}" "${files[@]}") || _fail markdownlint
+  fi
+fi
+
+# node-floor
+if _skipped node-floor; then echo "== node-floor: skipped by input"; else
+  _header node-floor
+  bash "${config_dir}/check-node-floor.sh" "${repo}" "${node_floor}" || _fail node-floor
+fi
+
+echo
+if ((failures > 0)); then
+  echo "::error::standards-check: ${failures} linter(s) failed"
+  exit 1
+fi
+echo "standards-check: all enabled linters clean"
+```
+
+- [ ] **Step 4: Run the test until it passes**
+
+Run: `bash /Users/andrewrich/Developer/github-workflows/tests/test-run-standards.sh`
+Expected: `9 passed, 0 failed`. If a "rejected" case is accepted, read `${tmp}/<fixture>.log` and fix the *fixture* only if the linter genuinely does not flag it at that severity; never loosen the runner to make a fixture pass. If `bad-zizmor` is accepted, confirm zizmor's `unpinned-uses` fires with the canonical policy (`"*": hash-pin` on `actions/checkout@v7`).
+
+Run: `shellcheck -S info /Users/andrewrich/Developer/github-workflows/standards/run-standards.sh /Users/andrewrich/Developer/github-workflows/tests/test-run-standards.sh`
+Expected: silent.
+
+- [ ] **Step 5: Dogfood on the repo itself**
+
+Run: `bash /Users/andrewrich/Developer/github-workflows/standards/run-standards.sh --repo /Users/andrewrich/Developer/github-workflows`
+Expected: exit 0. If it fails, fix the findings in `github-workflows` in this same commit (they are real) and record which in the report.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/andrewrich/Developer/github-workflows add standards/run-standards.sh tests/test-run-standards.sh
+git -C /Users/andrewrich/Developer/github-workflows commit -m "feat(standards): run-standards.sh with known-bad fixture tests"
+```
+
+---
+
+### Task 3: The reusable workflow and its self-applying caller
+
+**Files:**
+
+- Create: `.github/workflows/standards-check.yml`
+- Create: `.github/workflows/self-standards-check.yml`
+- Modify: `zizmor.yml` (add `standards-check.yml` to the `excessive-permissions` ignore list)
+
+**Interfaces:**
+
+- Consumes: `standards/run-standards.sh` CLI (Task 2); `standards/` configs (Task 1).
+- Produces: reusable workflow `smartwatermelon/github-workflows/.github/workflows/standards-check.yml` with inputs `shellcheck`, `yamllint`, `actionlint`, `zizmor`, `markdownlint`, `node_floor_check` (booleans, default `true`), `node_floor` (string, default `"22"`); inner job id `run-standards-check`. W2's caller stub uses these names.
+
+- [ ] **Step 1: Write the reusable workflow**
+
+`.github/workflows/standards-check.yml`:
+
+```yaml
+name: Standards Check
+
+# Reusable, deterministic, secret-free standards check. Replaces the CI
+# judgment reviewer as the fleet's required check (dev-env#60,
+# github-workflows#154). Installs pinned linters and runs
+# standards/run-standards.sh from THIS repo at the SHA the caller resolved
+# (github.job_workflow_sha), so the script, the configs, and the workflow
+# always agree.
+#
+# Caller stub (name the job `standards-check`; the required check is then
+# `standards-check / run-standards-check`):
+#
+#   name: Standards Check
+#   on:
+#     pull_request:
+#       types: [opened, synchronize, ready_for_review, reopened]
+#   permissions:
+#     contents: read
+#   jobs:
+#     standards-check:
+#       uses: smartwatermelon/github-workflows/.github/workflows/standards-check.yml@standards-check-v1
+#
+# Tool versions are pinned here and verified by checksum. Bump them by PR.
+
+on:
+  workflow_call:
+    inputs:
+      shellcheck:
+        description: Run shellcheck -S info over shell files
+        type: boolean
+        default: true
+      yamllint:
+        description: Run yamllint over YAML files
+        type: boolean
+        default: true
+      actionlint:
+        description: Run actionlint over .github/workflows
+        type: boolean
+        default: true
+      zizmor:
+        description: Run zizmor over .github/workflows
+        type: boolean
+        default: true
+      markdownlint:
+        description: Run markdownlint-cli2 over Markdown files
+        type: boolean
+        default: true
+      node_floor_check:
+        description: Fail on Node.js pins below node_floor
+        type: boolean
+        default: true
+      node_floor:
+        description: Lowest supported Node.js major
+        type: string
+        default: "22"
+
+permissions: {}
+
+env:
+  SHELLCHECK_VERSION: "0.11.0"
+  SHELLCHECK_SHA256: "8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
+  ACTIONLINT_VERSION: "1.7.12"
+  ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+  ZIZMOR_VERSION: "1.30.0"
+  ZIZMOR_SHA256: "ec8c95cd800845abb9bbc5f377ec7c57d2eb8e2386a00a201d3a74ee4092e5ed"
+  YAMLLINT_VERSION: "1.38.0"
+  MARKDOWNLINT_CLI2_VERSION: "0.23.2"
+
+jobs:
+  run-standards-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout caller repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          path: repo
+
+      - name: Checkout standards at the called-workflow SHA
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: smartwatermelon/github-workflows
+          ref: ${{ github.job_workflow_sha }}
+          persist-credentials: false
+          fetch-depth: 1
+          path: standards-src
+          sparse-checkout: |
+            standards
+            zizmor.yml
+
+      - name: Install pinned linters
+        env:
+          SKIP_SHELLCHECK: ${{ inputs.shellcheck == false }}
+          SKIP_ACTIONLINT: ${{ inputs.actionlint == false }}
+          SKIP_ZIZMOR: ${{ inputs.zizmor == false }}
+          SKIP_YAMLLINT: ${{ inputs.yamllint == false }}
+          SKIP_MARKDOWNLINT: ${{ inputs.markdownlint == false }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${HOME}/.local/bin"; echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          if [ "${SKIP_SHELLCHECK}" != "true" ]; then
+            curl -Lfso /tmp/shellcheck.tar.xz \
+              "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+            echo "${SHELLCHECK_SHA256}  /tmp/shellcheck.tar.xz" | sha256sum -c -
+            tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+            install -m 0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" "${HOME}/.local/bin/shellcheck"
+          fi
+          if [ "${SKIP_ACTIONLINT}" != "true" ]; then
+            curl -Lfso /tmp/actionlint.tar.gz \
+              "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+            echo "${ACTIONLINT_SHA256}  /tmp/actionlint.tar.gz" | sha256sum -c -
+            tar -xzf /tmp/actionlint.tar.gz -C /tmp actionlint
+            install -m 0755 /tmp/actionlint "${HOME}/.local/bin/actionlint"
+          fi
+          if [ "${SKIP_ZIZMOR}" != "true" ]; then
+            curl -Lfso /tmp/zizmor.tar.gz \
+              "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+            echo "${ZIZMOR_SHA256}  /tmp/zizmor.tar.gz" | sha256sum -c -
+            mkdir -p /tmp/zizmor && tar -xzf /tmp/zizmor.tar.gz -C /tmp/zizmor
+            install -m 0755 "$(find /tmp/zizmor -type f -name zizmor | head -1)" "${HOME}/.local/bin/zizmor"
+          fi
+          if [ "${SKIP_YAMLLINT}" != "true" ]; then
+            pipx install "yamllint==${YAMLLINT_VERSION}"
+          fi
+          if [ "${SKIP_MARKDOWNLINT}" != "true" ]; then
+            npm install -g "markdownlint-cli2@${MARKDOWNLINT_CLI2_VERSION}"
+          fi
+
+      - name: Run standards
+        env:
+          SKIP_LIST: >-
+            ${{ inputs.shellcheck == false && 'shellcheck,' || '' }}${{ inputs.yamllint == false && 'yamllint,' || '' }}${{ inputs.actionlint == false && 'actionlint,' || '' }}${{ inputs.zizmor == false && 'zizmor,' || '' }}${{ inputs.markdownlint == false && 'markdownlint,' || '' }}${{ inputs.node_floor_check == false && 'node-floor,' || '' }}
+          NODE_FLOOR: ${{ inputs.node_floor }}
+        run: |
+          set -euo pipefail
+          [[ "${NODE_FLOOR}" =~ ^[0-9]+$ ]] || { echo "::error::node_floor must be an integer major"; exit 2; }
+          bash standards-src/standards/run-standards.sh \
+            --repo repo \
+            --config-dir standards-src/standards \
+            --skip "${SKIP_LIST%,}" \
+            --node-floor "${NODE_FLOOR}"
+```
+
+- [ ] **Step 2: Write the self-applying caller**
+
+`.github/workflows/self-standards-check.yml`:
+
+```yaml
+name: Self Standards Check
+
+# Self-applying caller: runs this repo's reusable standards-check.yml on its
+# own PRs via a local path, so a PR that changes the check dogfoods itself.
+# Produces the `standards-check / run-standards-check` status check.
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  standards-check:
+    uses: ./.github/workflows/standards-check.yml
+```
+
+Note: with a local `uses: ./...`, `github.job_workflow_sha` is the PR head SHA, so the sparse checkout in Step 1 fetches the same commit. Verify this in Step 5's run log.
+
+- [ ] **Step 3: Extend `zizmor.yml`**
+
+Add under `excessive-permissions.ignore`, keeping the comment style of the existing entries:
+
+```yaml
+      - standards-check.yml # caller for standards-check.yml
+```
+
+- [ ] **Step 4: Lint locally and run the suite**
+
+Run:
+
+```bash
+cd /Users/andrewrich/Developer/github-workflows && actionlint && zizmor --config zizmor.yml --min-severity low --no-online-audits . && yamllint -c standards/yamllint.yml .github/workflows/standards-check.yml .github/workflows/self-standards-check.yml && bash tests/run-tests.sh && bash standards/run-standards.sh
+```
+
+(`cd` inside a single subshell command is acceptable here because the linters resolve paths relative to the repo root; do not rely on it persisting.)
+Expected: all silent/passing. Fix any finding in the new files.
+
+- [ ] **Step 5: Commit, push, open the PR, and read the run log**
+
+```bash
+git -C /Users/andrewrich/Developer/github-workflows add .github/workflows/standards-check.yml .github/workflows/self-standards-check.yml zizmor.yml
+git -C /Users/andrewrich/Developer/github-workflows commit -m "feat: standards-check.yml reusable workflow with self-applying caller"
+git -C /Users/andrewrich/Developer/github-workflows push -u origin <branch>
+gh pr create --repo smartwatermelon/github-workflows --head <branch> --title "feat: standards-check.yml, the deterministic required check (W1)" --body "<body>"
+```
+
+Then wait for the `standards-check / run-standards-check` check and read its log:
+
+```bash
+gh run list --repo smartwatermelon/github-workflows --workflow self-standards-check.yml --limit 1 --json databaseId,conclusion
+gh run view <id> --repo smartwatermelon/github-workflows --log | grep -E "sha256sum|OK$|== |standards-check:|job_workflow_sha|Checkout standards" | head -40
+```
+
+Expected: every checksum line reads `OK`; six `== <linter>` headers; final line `standards-check: all enabled linters clean`; the standards checkout resolved the PR head SHA. A green check without those log lines is not evidence.
+
+---
+
+### Task 4: Known-bad validation on a throwaway PR
+
+**Files:** none kept. A scratch branch off the Task 3 branch.
+
+- [ ] **Step 1: Push a deliberately failing commit**
+
+```bash
+git -C /Users/andrewrich/Developer/github-workflows checkout -b claude/scratch-standards-known-bad-<session>
+printf '#!/usr/bin/env bash\necho $1\n' > /Users/andrewrich/Developer/github-workflows/standards/_known_bad.sh
+git -C /Users/andrewrich/Developer/github-workflows add standards/_known_bad.sh
+git -C /Users/andrewrich/Developer/github-workflows commit -m "test: known-bad fixture for standards-check (DO NOT MERGE)"
+git -C /Users/andrewrich/Developer/github-workflows push -u origin claude/scratch-standards-known-bad-<session>
+gh pr create --repo smartwatermelon/github-workflows --head claude/scratch-standards-known-bad-<session> --base <task-3-branch> --draft --title "DO NOT MERGE: standards-check known-bad validation" --body "Throwaway. Proves standards-check fails on a real SC2086. Closed after the run."
+```
+
+If the local pre-commit hook blocks the commit on the shellcheck finding, that is the hook doing its job: bypassing is forbidden, so instead create the file via the GitHub Contents API on the scratch branch:
+
+```bash
+gh api -X PUT repos/smartwatermelon/github-workflows/contents/standards/_known_bad.sh -f branch=claude/scratch-standards-known-bad-<session> -f message="test: known-bad fixture (DO NOT MERGE)" -f content="$(printf '#!/usr/bin/env bash\necho $1\n' | base64)"
+```
+
+- [ ] **Step 2: Confirm the check FAILS for the right reason**
+
+```bash
+gh pr checks <scratch-pr> --repo smartwatermelon/github-workflows --watch
+gh run view <id> --repo smartwatermelon/github-workflows --log | grep -E "SC2086|::error::shellcheck|standards-check: [0-9]+ linter"
+```
+
+Expected: `standards-check / run-standards-check` is **failing**, the log names `SC2086` in `standards/_known_bad.sh`, and the summary line reports 1 linter failed.
+
+- [ ] **Step 3: Close the scratch PR and delete the branch**
+
+```bash
+gh pr close <scratch-pr> --repo smartwatermelon/github-workflows --delete-branch
+git -C /Users/andrewrich/Developer/github-workflows checkout <task-3-branch>
+git -C /Users/andrewrich/Developer/github-workflows branch -D claude/scratch-standards-known-bad-<session>
+```
+
+Record the scratch PR number, the failing run id, and the grep output in the report.
+
+---
+
+### Task 5: Documentation
+
+**Files:**
+
+- Modify: `README.md` (new section after the `dependabot-auto-merge.yml` section; versioning table gains the `standards-check-v1` namespace)
+- Modify: `CLAUDE.md` (mention `tests/run-tests.sh` and `standards/run-standards.sh`)
+
+- [ ] **Step 1: README section**
+
+Add a `## standards-check.yml` section containing: purpose (deterministic required check replacing the judgment reviewer, per dev-env#60 and #154), the caller stub from the workflow header verbatim, the inputs table (seven inputs, types, defaults), the check name `standards-check / run-standards-check`, config precedence (repo root wins, else `standards/`), the pinned tool versions table with a sentence that bumps are manual PRs, the local command `bash standards/run-standards.sh --repo <dir>`, and a "Versioning" note: tags `standards-check-vX.Y.Z` (exact) and `standards-check-v1` (floating, recommended for callers), moved manually and human-authorized like `v3`.
+
+- [ ] **Step 2: CLAUDE.md**
+
+Add under the repo's testing/lint guidance: `bash tests/run-tests.sh` runs the standards suites (requires the five linters via Homebrew); `bash standards/run-standards.sh` is the same check CI runs.
+
+- [ ] **Step 3: Lint, commit, push**
+
+Run: `markdownlint-cli2 --config /Users/andrewrich/Developer/github-workflows/standards/markdownlint.json /Users/andrewrich/Developer/github-workflows/README.md /Users/andrewrich/Developer/github-workflows/CLAUDE.md`
+Expected: silent.
+
+```bash
+git -C /Users/andrewrich/Developer/github-workflows add README.md CLAUDE.md
+git -C /Users/andrewrich/Developer/github-workflows commit -m "docs: document standards-check.yml, its inputs, and its tag namespace"
+git -C /Users/andrewrich/Developer/github-workflows push
+```
+
+---
+
+## After merge (human steps, one sitting)
+
+1. **Tag the release** (floating-tag moves are human-authorized by this repo's own policy):
+
+   ```bash
+   git -C /Users/andrewrich/Developer/github-workflows switch main && git -C /Users/andrewrich/Developer/github-workflows pull
+   git -C /Users/andrewrich/Developer/github-workflows tag -a standards-check-v1.0.0 -m "standards-check v1.0.0"
+   git -C /Users/andrewrich/Developer/github-workflows tag -f standards-check-v1 standards-check-v1.0.0
+   git -C /Users/andrewrich/Developer/github-workflows push origin standards-check-v1.0.0 standards-check-v1
+   ```
+
+2. W2 begins with the four pilots (`repo-template`, `pr-review`,
+   `claude-code-workflows-agents`, `nightowlstudiollc/.github`) calling
+   `@standards-check-v1`. W2 gets its own plan.

--- a/docs/superpowers/specs/2026-09-03-org-migration-design.md
+++ b/docs/superpowers/specs/2026-09-03-org-migration-design.md
@@ -1,9 +1,9 @@
 # Design: Org Migration (I3) and Token Scope Escape Hatch (F4)
 
-Status: APPROVED IN CHAT 2026-09-03 — spec under review before the
-implementation plan. Executes items I3 and F4 of
-`2026-09-01-infrastructure-backlog-design.md`. Supersedes the phase plan in
-`smartwatermelon/dev-env#54` while keeping its goal.
+Status: EXECUTED 2026-09-04 as a rename-then-reclaim. 25 of 30 repos
+transferred; five paths permanently retired (see `docs/STATUS.md`). Findings
+and deviations are in dev-env#54's closing comment and dev-env#84. Executes
+items I3 and F4 of `2026-09-01-infrastructure-backlog-design.md`.
 
 ## Purpose
 

--- a/docs/superpowers/specs/2026-09-03-org-migration-design.md
+++ b/docs/superpowers/specs/2026-09-03-org-migration-design.md
@@ -1,7 +1,7 @@
 # Design: Org Migration (I3) and Token Scope Escape Hatch (F4)
 
 Status: EXECUTED 2026-09-04 as a rename-then-reclaim. 25 of 30 repos
-transferred; five paths permanently retired (see `docs/STATUS.md`). Findings
+transferred; five paths retired pending support ticket 4729524 (see `docs/STATUS.md`). Findings
 and deviations are in dev-env#54's closing comment and dev-env#84. Executes
 items I3 and F4 of `2026-09-01-infrastructure-backlog-design.md`.
 

--- a/scripts/org-migration/move-list.txt
+++ b/scripts/org-migration/move-list.txt
@@ -4,27 +4,32 @@
 # transferred first and alone via `transfer.sh --only github-workflows`
 # (design Step 3).
 # cleanroom is the one repo that targets nightowlstudiollc.
+# Five repos target twistedmelonman: their smartwatermelon/<name> paths are
+# permanently retired by GitHub (popular-repository namespace retirement,
+# HTTP 422 on transfer and on create). They stay on the user account with
+# working redirects. Support ticket 4729524; assume denial. See
+# docs/STATUS.md "Deferred by decision".
 .github	smartwatermelon
 archive-resolver	smartwatermelon
 claude-code-workflows-agents	smartwatermelon
-claude-config	smartwatermelon
+claude-config	twistedmelonman
 claude-config-backup	smartwatermelon
 claude-wrapper	smartwatermelon
 cleanroom	nightowlstudiollc
 crazy-larry	smartwatermelon
 dev-env	smartwatermelon
-dotfiles	smartwatermelon
+dotfiles	twistedmelonman
 dumbify	smartwatermelon
 github-workflows	smartwatermelon
 gmail-newsletter-filter	smartwatermelon
 homebrew-tap	smartwatermelon
-huddle-transcribe	smartwatermelon
+huddle-transcribe	twistedmelonman
 lock-sync	smartwatermelon
 mac-dev-server-setup	smartwatermelon
 mac-server-setup	smartwatermelon
-personify	smartwatermelon
+personify	twistedmelonman
 pr-review	smartwatermelon
-projectinsomnia	smartwatermelon
+projectinsomnia	twistedmelonman
 qwen-sidebar	smartwatermelon
 repo-template	smartwatermelon
 scripts	smartwatermelon

--- a/scripts/org-migration/move-list.txt
+++ b/scripts/org-migration/move-list.txt
@@ -4,11 +4,12 @@
 # transferred first and alone via `transfer.sh --only github-workflows`
 # (design Step 3).
 # cleanroom is the one repo that targets nightowlstudiollc.
-# Five repos target twistedmelonman: their smartwatermelon/<name> paths are
-# permanently retired by GitHub (popular-repository namespace retirement,
-# HTTP 422 on transfer and on create). They stay on the user account with
-# working redirects. Support ticket 4729524; assume denial. See
-# docs/STATUS.md "Deferred by decision".
+# Five repos target twistedmelonman as an INTERIM shim: their
+# smartwatermelon/<name> paths are retired by GitHub (popular-repository
+# namespace retirement, HTTP 422 on transfer and on create). They stay on
+# the user account with working redirects while support ticket 4729524 is
+# open. If GitHub releases the paths, flip these five back to
+# smartwatermelon and re-run transfer.sh. See docs/STATUS.md.
 .github	smartwatermelon
 archive-resolver	smartwatermelon
 claude-code-workflows-agents	smartwatermelon


### PR DESCRIPTION
## Summary

- Record the five permanently retired repo paths (`claude-config`, `dotfiles`, `huddle-transcribe`, `personify`, `projectinsomnia`) in `scripts/org-migration/move-list.txt` as targeting `twistedmelonman`, so `verify.sh` and the Task 11 repoint loop stop flagging them as drift.
- Mark `docs/superpowers/specs/2026-09-03-org-migration-design.md` as EXECUTED (2026-09-04), replacing the stale "approved, spec under review" status line.
- Refresh `docs/STATUS.md`: update the as-of date to 2026-09-08, update the layer-state table (L1/N1a/F3 done, migration cleanup done), and record the 2026-09-08 W1 decisions.

The W1 decisions recorded: no CI judgment reviewer stays (`standards-check.yml` replaces `claude-blocking-review.yml` outright, local hooks are the only judgment pass); `nightowl-restore-blocking-review.sh` is retired with W3; #89 gates only `smartwatermelon/.github` (the other three ungated repos stay that way by decision); #85 is audit-only (full-history secret audit of `scripts`, then stop and report).

## Test plan

- [x] `scripts/org-migration/tests/run-tests.sh` — 38/38 pass, exit 0
- [x] Repoint-loop read-only check — no drift output (previously flagged `claude-config` and `huddle-transcribe`)
- [x] Pre-push codebase review dry-run — PASS
- [x] Full-diff adversarial review (pre-push hook) — PASS

https://claude.ai/code/session_019HDRKLQNv82SEBd4zGpcXf