### PR TITLE
chore: clear markdownlint debt (wave 3 pilot)

### DIFF
--- a/docs/2026-08-31-github-settings-app-evaluation.md
+++ b/docs/2026-08-31-github-settings-app-evaluation.md
@@ -49,12 +49,12 @@ permissions, and classic branch-protection rules (required status checks, requir
 reviews, `enforce_admins`, push restrictions).
 
 **Org-wide defaults**: if installed at the org level and `smartwatermelon/.github`
-carries a `.github/settings.yml`, that file becomes the *default* applied to every
+carries a `.github/settings.yml`, that file becomes the _default_ applied to every
 repo that doesn't ship its own override — array fields (labels, branch rules) merge
 by name rather than replacing wholesale. This is a direct, better-fitting answer to
 what `.github` already does for `FUNDING.yml`.
 
-**What it does *not* cover**: Actions permissions
+**What it does _not_ cover**: Actions permissions
 (`default_workflow_permissions`, `can_approve_pull_request_reviews`, allowed-actions
 policy), Actions/Dependabot secrets and variables, environments, webhooks, GitHub
 Pages, and the newer repository **rulesets** feature (a distinct, more capable
@@ -82,7 +82,7 @@ options, feature toggles) that's genuinely useful, but does so by installing a
 permanently-running, admin-scoped, third-party-hosted webhook service across the
 entire org. That's a materially larger and more persistent trust surface than
 anything currently in the fleet — and directly cuts against the fleet's own
-recent direction (the 2026-03-25 infrastructure consolidation deliberately *removed*
+recent direction (the 2026-03-25 infrastructure consolidation deliberately _removed_
 remote dependencies — Sentry/Seer, `claude-code-review.yml`'s per-commit remote
 calls — in favor of local, deterministic, self-hosted automation). Adopting a
 standing admin-privileged external app to save a handful of `gh api` calls at repo
@@ -146,13 +146,13 @@ next increment given what already exists.
 **What it is**: Declarative repo-settings-as-code, run transiently in CI (plan on
 PR, apply on merge) rather than via a permanently-installed webhook app. Covers
 everything Options 1 and 2 cover, plus Actions permissions, environments, rulesets,
-and secret *existence* (not values) — using a token minted per-run rather than a
+and secret _existence_ (not values) — using a token minted per-run rather than a
 standing installation.
 
 **Fit for our workflow**: This is the option that actually matches the fleet's
 stated philosophy — "one repo, one source of truth" — extended from local
 dev-machine config (`install.sh`) to org-wide repo config. It's also the only option
-here that could reconcile drift across the *existing* fleet, not just new repos. The
+here that could reconcile drift across the _existing_ fleet, not just new repos. The
 cost is real, though: authoring HCL, an initial `terraform import` pass across
 ~30+ active repos, and picking a state backend. This is a larger, separate project,
 not a drop-in replacement for `repo-template`/`.github` — worth its own design doc if

--- a/docs/plans/2026-08-27-workflow-sha-pinning.md
+++ b/docs/plans/2026-08-27-workflow-sha-pinning.md
@@ -16,10 +16,12 @@ The propagation-without-manual-review problem is already solved end to end; only
 
 - `smartwatermelon/github-workflows` publishes reusable workflows, tagged (`v3`, etc.) — a separate repo, not attached to this session.
 - Every consumer repo (16, per `docs/plans/2026-04-28-dependabot-auto-merge-c2.md`) references reusable workflows by **floating tag**:
+
   ```yaml
   # .github/workflows/claude-blocking-review.yml:21
   uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3
   ```
+
   This is what zizmor flags — the ref is mutable, not a pin.
 - Every consumer repo has `.github/dependabot.yml` (github-actions ecosystem, `directory: "/"`, weekly) which already watches these `uses:` lines and opens bump PRs automatically.
 - Every consumer repo has its own copy of `.github/workflows/dependabot-auto-merge.yml`, which auto-approves and auto-merges patch/minor bumps, and — per the C2 rollout — major bumps too, as long as every dependency in the bump is in a trusted namespace (`dependabot/`, `actions/`, `smartwatermelon/`).
@@ -33,15 +35,19 @@ Net effect today: a new `github-workflows` release already reaches all 16 repos 
 ## Target State
 
 1. Consumer `uses:` lines are pinned to a full commit SHA, with a trailing version comment for humans and for Dependabot's resolver:
+
    ```yaml
    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@<40-char-sha> # v3.0.1
    ```
+
    Dependabot's github-actions updater reads the comment to resolve the semantic version, and on a new `github-workflows` release opens a PR bumping both the SHA and the comment — the same weekly job already running, now producing a ref zizmor accepts as pinned (it checks the literal ref, not the comment).
 
 2. The auto-merge policy itself becomes a single reusable workflow in `github-workflows`, called by SHA-pinned reference from each consumer, instead of 16 copies of the policy logic:
+
    ```yaml
    uses: smartwatermelon/github-workflows/.github/workflows/dependabot-auto-merge.yml@<sha> # v1.0.0
    ```
+
    Editing the merge policy becomes one PR + release in `github-workflows`, which then propagates itself the same Dependabot-driven way.
 
 3. `.github/dependabot.yml` needs no changes — it already covers this.
@@ -92,9 +98,11 @@ Consistent with how the C2 rollout was sequenced (dev-env validated end-to-end b
 
 - Resolve the commit SHA behind the current `v3` tag on `github-workflows`.
 - Edit `dev-env/.github/workflows/claude-blocking-review.yml:21`:
+
   ```yaml
   uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@<sha> # v3.0.1
   ```
+
 - Preserve the existing comment above it explaining the floating-@v3-not-a-job-level-if rationale — that reasoning is unrelated to the pin format and still applies.
 
 ### Task 2.2: Point `dependabot-auto-merge.yml` at the new reusable workflow


### PR DESCRIPTION
## What was broken

`dev-env` failed `standards-check` on markdownlint: 18 findings across two
documents, both last touched 2026-08-30, neither related to any recent change.

- `docs/2026-08-31-github-settings-app-evaluation.md` — 10x MD049
  (emphasis-style: `*text*` where the config expects `_text_`)
- `docs/plans/2026-08-27-workflow-sha-pinning.md` — 8x MD031
  (fenced code blocks not surrounded by blank lines)

This is the debt that turned up red on #105 and, in claude-config, on #482 —
neither of which touched lint.

## How it was fixed

`markdownlint-cli2 --fix` against the canonical config
(`github-workflows/standards/markdownlint.json`, the same file CI uses). The
entire diff is emphasis markers and blank lines. No prose changed.

## Verification

Gated on the CI runner, not the linter alone:

```console
$ bash standards/run-standards.sh --repo ~/Developer/dev-env
RUNNER_EXIT=0
== shellcheck / yamllint / actionlint / zizmor / markdownlint / node-floor
Summary: 0 issues in 0 files
Node floor 22: OK
```

The same runner was executed on `main` **before** the fix as a known-bad
control, and reproduced the exact MD049/MD031 findings CI reported on #105 —
so this clean run is a measurement, not a config mismatch reading green.

## Why the whole repo, in one commit

`standards-check` scans the entire repo on each PR run. A partial fix would
leave the check red on its own PR, and `pre-merge-review.sh` blocks on failing
CI checks regardless of whether they are required (#106) — so it would block
the very commit that clears the debt. Taking a repo fully green in one shot is
what makes wave 3 self-unblocking under the current hook.

## Scope

Pilot for wave 3 of the standards-check rollout. Fifteen repos are red on
wave-3 linters; the rest of the fleet follows once this validates the loop
end-to-end.

Advances #106

https://claude.ai/code/session_01UaPoEix1iED8ENCZCa12jy
