### PR TITLE
docs: correct the whole-repo fallback measurement to zero

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -307,9 +307,16 @@ confirming waves 1–2 landed cleanly.
 **`standards-check` is required on zero repos, so W3 has not started
 anywhere.** Wave 3 no longer gates it: after `github-workflows#165` the
 required-check contract is "no new debt in files this PR touches", not "this
-repo is clean". The actual gate is the base-SHA whole-repo fallback, measured
-firing in **4 of 15 sampled runs (~27%)** — harmless only while the check is
-non-required. See `docs/superpowers/plans/2026-09-10-backlog-evaluation.md`.
+repo is clean".
+
+An earlier revision of this line named the base-SHA whole-repo fallback as the
+remaining gate, firing in "4 of 15 sampled runs (~27%)". **That measurement was
+wrong; re-measured 2026-09-11 the fallback rate is zero** — the classifier had
+matched the script text that `gh run view --log` echoes before execution, and
+counted pre-tag-move runs (which have no scoping step at all) as fallbacks. No
+fallback gate exists. See
+`docs/superpowers/plans/2026-09-10-backlog-evaluation.md` for the full
+correction.
 
 **Wave 3 (combined shellcheck/markdownlint/yamllint, ~26 repos) — cleared to
 proceed by Andrew 2026-09-09.** It is the main path to moving repos out of

--- a/docs/superpowers/plans/2026-09-10-backlog-evaluation.md
+++ b/docs/superpowers/plans/2026-09-10-backlog-evaluation.md
@@ -63,21 +63,43 @@ Three repos have no branch protection at all (`claude-config-backup`,
 `superpowers`, `superpowers-marketplace`) — consistent with the dev-env#89
 decision to leave them ungated.
 
-### The real W3 gate: the whole-repo fallback rate
+### The whole-repo fallback rate — measured at zero (corrected 2026-09-11)
 
 When the base-SHA fetch fails, `standards-check` falls back to a whole-repo
 sweep rather than linting zero files. That was a deliberate fail-closed choice
-and it is the correct default. But it is not rare:
+and it is the correct default.
 
-**The fallback fired in 4 of 15 recent runs sampled across 8 repos (~27%)** —
-`twistedmelonman/claude-config` three times, `smartwatermelon/dev-env` once.
-All four runs passed, so the behavior is currently invisible.
+> **Correction.** This section previously reported the fallback firing in 4 of
+> 15 sampled runs (~27%) and named that the real W3 gate. **That measurement
+> was wrong and the conclusion built on it does not stand.** Re-measured
+> 2026-09-11 against 20 runs across 5 repos: the fallback fired **zero**
+> times. Every run that carried the scoping step narrowed correctly.
 
-It stops being invisible the moment the check becomes required: on a repo still
-carrying whole-repo debt, a fallback turns a routine PR into a hard block for
-reasons its author cannot see in the diff. **Measure and address the fallback
-rate before flipping W3, not after.** This is the gate; whole-repo cleanliness
-is not.
+Two errors produced the bad number:
+
+1. **The classifier matched the script, not its output.** `gh run view --log`
+   echoes each `run:` block's source before executing it, so every run's log
+   contains the literal strings `no pull_request base sha` and `could not fetch
+   base` whether or not that branch ever ran. Grepping for them matches 100% of
+   runs by construction. Filtering to real output lines shows all 13 scoped runs
+   printing `scoping to files changed since <sha>`.
+2. **Runs predating the tag move were counted as fallbacks.** The remaining 7
+   runs have no "Resolve scope" step at all — they ran a `@standards-check-v1`
+   that pointed at a pre-#165 commit. The annotated tag moved to `a446889` at
+   **2026-09-11T01:25:44Z**; every unscoped run started before that timestamp
+   and every scoped run after it, with no exceptions. The apparent "21-minute
+   cluster" was the tag move itself, not a transient.
+
+The general lesson is the one already in CLAUDE.md: *resolve the thing, don't
+match its label* — and validate against a known-bad case, which here would have
+meant confirming the classifier could report a non-fallback at all.
+
+**Consequence for W3: there is no fallback gate to clear.** The item below that
+ranked this as the blocker is withdrawn. What remains before flipping any check
+to required is the ordinary question of per-repo readiness, plus one real
+diagnostic gap: line 141's warning is emitted with the fetch's stderr discarded
+(`2>/dev/null`), so a genuine future failure would say *that* it happened but
+never *why*. Worth fixing on its own merits, not as a W3 blocker.
 
 ## 3. "Local hooks are the only judgment pass" still holds, but its subject is unowned
 
@@ -157,7 +179,7 @@ design session. Backlog ordering is left alone here rather than pre-empted.
 | Order | Work | Why it is here |
 | --- | --- | --- |
 | 1 | Credentials: `#1258`/`#1264`/`#1265`, `#79` | Has a deadline; off-plan |
-| 2 | Investigate the ~27% whole-repo fallback rate | The actual W3 gate |
+| ~~2~~ | ~~Whole-repo fallback rate~~ | Withdrawn — measured zero |
 | 3 | **W3** — `standards-check` required | Wave 3 no longer gates it |
 | 4 | New L item: local-reviewer reliability | Sole judgment gate, unowned |
 | 5 | `dev-env#109` + `#101` — mobile merge auth | Makes the merge gate real |
@@ -173,9 +195,15 @@ Both disciplines paid out again in this evaluation:
 **Resolve the thing; don't match its label.** A `standards-check` run reporting
 `success` is a claim about changed files, not about the repository. `null` in a
 jq-rendered readiness table is a stringified absent record, not a state. `#62`
-names a different issue than the document citing it assumes.
+names a different issue than the document citing it assumes. And — added
+2026-09-11, at this document's own expense — a workflow log containing the
+string `could not fetch base` is not a run that could not fetch the base. The
+log echoes the script before running it, so the label appears in every run.
 
-**Validate every fix against a known-bad case.** The fallback path is the open
-instance: it is correct by construction and has never been observed failing a
-PR, because nothing has yet made it block one. Its 27% firing rate is only
-harmless while the check is non-required.
+**Validate every fix against a known-bad case.** The withdrawn fallback finding
+is now the worked example rather than the open instance. The classifier that
+produced "~27%" was never checked against a run known *not* to have fallen
+back; had it been, it would have reported a fallback there too and exposed
+itself immediately. A measurement that cannot return a negative is not a
+measurement. This document asserted the discipline in one section while
+violating it in another — which is the failure mode worth remembering.


### PR DESCRIPTION
The 2026-09-10 evaluation reported the `standards-check` base-SHA fallback firing in **4 of 15 sampled runs (~27%)** and named that the real W3 gate. Re-measured across 20 runs on 5 repos: **the fallback rate is zero.** The conclusion built on it is withdrawn.

## What went wrong

**1. The classifier matched the script, not its output.** `gh run view --log` echoes each `run:` block source before executing it, so every log contains the literal strings `no pull_request base sha` and `could not fetch base` whether or not that branch ran. Grepping for them matches 100% of runs by construction. Filtering to real output lines shows all 13 scoped runs printing `scoping to files changed since <sha>`.

**2. Pre-tag-move runs were counted as fallbacks.** The other 7 runs have no `Resolve scope` step at all — they ran a `@standards-check-v1` pointing at a pre-#165 commit. The annotated tag moved to `a446889` at **2026-09-11T01:25:44Z**; every unscoped run started before that timestamp and every scoped run after, no exceptions. The apparent "21-minute cluster" was the tag move itself, not a transient.

The classifier was never validated against a run known *not* to have fallen back — it would have reported a fallback there too, exposing itself immediately. A measurement that cannot return a negative is not a measurement.

## Consequence

There is no fallback gate to clear before W3. The recommended-order item ranking it as the blocker is struck through rather than deleted, so the reasoning stays auditable.

One real gap survives, on its own merits rather than as a W3 blocker: `standards-check.yml:141` emits its warning with the fetch stderr discarded (`2>/dev/null`), so a genuine future failure reports *that* it happened but never *why*. Not fixed here — this PR is documentation only.

## Verification

- Reclassified all 20 runs with an output-only matcher; raw results in the session scratchpad.
- Confirmed the unscoped runs lack the step via the jobs API, not by log grep.
- `markdownlint` clean on the evaluation doc; the 11 MD013 errors in `STATUS.md` are pre-existing (11 before, 11 after) and outside this diff.

https://claude.ai/code/session_01ESsw699T54JHARkQXrdL3o