### PR TITLE
docs: preserve the superpowers token-consumption research before it was lost

### DIFF
--- a/docs/research/superpowers-token-consumption/DRAFT-BUG-REPORT.md
+++ b/docs/research/superpowers-token-consumption/DRAFT-BUG-REPORT.md
@@ -1,0 +1,340 @@
+# Bug Report: Hard-Stop Token Limit Failures with subagent-driven-development
+
+## Summary
+
+Using the `subagent-driven-development` skill causes hard-stop token limit failures in Claude Code sessions, even when auto-compaction is enabled. This appears to be caused by invisible token consumption from heavy subagent usage exceeding the 200K context limit.
+
+---
+
+## Environment
+
+- **Claude Code Version:** [Your version]
+- **Plugin:** Superpowers v4.0.3
+- **OS:** macOS / Linux / Windows
+- **Auto-compaction:** Enabled in settings
+- **Skill Used:** `subagent-driven-development`
+
+---
+
+## Steps to Reproduce
+
+1. Install Superpowers plugin via marketplace
+2. Enable auto-compaction in Claude Code settings
+3. Create an implementation plan with 10+ tasks (using `writing-plans` skill)
+4. Execute the plan using `subagent-driven-development` skill
+5. Observe session behavior as tasks are implemented
+
+---
+
+## Expected Behavior
+
+- Auto-compaction should activate when approaching token limits
+- Session should continue operating without hard-stop failures
+- User should receive warnings before hitting limits
+- Token usage should be visible to the user
+
+---
+
+## Actual Behavior
+
+- Session hits hard-stop token limit failure
+- No auto-compaction recovery occurs
+- No prior warnings about token consumption
+- Session becomes unusable and cannot continue
+- Subagent token usage is invisible to user
+
+---
+
+## Evidence
+
+### 1. Test Data Shows Massive Token Consumption
+
+From Superpowers integration tests (`docs/testing.md`):
+
+**5-task minimal test case:**
+
+```
+Total tokens: 1,524,058
+- Main session:  1,213,703 cache read tokens
+- 7 subagents:   1,382,835 cache read tokens
+```
+
+**Analysis:**
+
+- 1.5M tokens for just 5 tasks
+- 7.5x the 200K Claude Code context limit
+- Real-world 10-task plan: ~3M tokens (15x limit)
+- Real-world 20-task plan: ~6M tokens (30x limit)
+
+### 2. Subagent Multiplication Pattern
+
+`subagent-driven-development` spawns **3+ subagents per task:**
+
+```
+Per task:
+1. Implementer subagent (~25K tokens)
+2. Spec compliance reviewer subagent (~25K tokens)
+3. Code quality reviewer subagent (~25K tokens)
++ Review loops when issues found (additional subagents)
++ Final reviewer (25K tokens)
+
+10-task plan = ~32 subagents = ~800K tokens from subagents alone
+```
+
+### 3. Pattern Only Occurs with Superpowers
+
+**With Superpowers:**
+
+- Hard-stop failures occur regularly
+- Specifically when using `subagent-driven-development`
+- Auto-compaction does not prevent failures
+
+**Without Superpowers:**
+
+- No token limit failures observed
+- Auto-compaction works as expected
+- Normal Claude Code usage is stable
+
+---
+
+## Root Cause Analysis
+
+### Hypothesis: Subagent Tokens Count Against Parent Session Limit
+
+**Supporting evidence:**
+
+1. **Scale matches observed failures:**
+   - 7.5-30x context limit consumption for typical plans
+   - Hard-stops suggest hitting architectural limit, not just needing compaction
+
+2. **Invisible consumption:**
+   - Subagent usage via Task tool happens in background
+   - No visibility into cumulative token usage
+   - User has no way to monitor or prevent exhaustion
+
+3. **Compaction cannot recover:**
+   - If actively spawning 25K-token subagents near limit
+   - Compaction can't free space fast enough
+   - New subagents added faster than old context removed
+
+### Architectural Questions Requiring Clarification
+
+**Need answers from Claude Code team:**
+
+1. Do subagent tokens (via Task tool) count against the parent session's 200K limit?
+2. How does auto-compaction behave when subagents are actively being dispatched?
+3. Are prompt cache read tokens (1.4M in test) counted toward context limit?
+4. Should there be isolated token budgets for subagents vs. parent session?
+
+---
+
+## Comparison: Alternative Skill Avoids Issue
+
+### `executing-plans` - No Subagent Usage ✅
+
+```
+Execution model:
+- Parallel Claude Code session
+- Agent executes tasks directly (no Task tool)
+- Human review between batches
+- Traditional token accumulation only
+
+Result: No token limit failures observed
+```
+
+### `subagent-driven-development` - Heavy Subagent Usage ❌
+
+```
+Execution model:
+- Same session as user
+- 3+ subagents per task via Task tool
+- Fully autonomous execution
+- Massive token multiplication
+
+Result: Hard-stop failures on moderate-sized plans
+```
+
+**Decision criteria from skills:**
+
+```
+Have implementation plan?
+└─yes→ Tasks mostly independent?
+       └─yes→ Stay in this session?
+              ├─yes→ subagent-driven-development (token-heavy)
+              └─no→  executing-plans (token-safe)
+```
+
+---
+
+## Additional Context
+
+### Compaction Hook Gap
+
+**Current implementation:** `hooks/hooks.json`
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [{"command": "session-start.sh"}]
+      }
+    ]
+  }
+}
+```
+
+**Issue:** No distinction between session-start and post-compaction events
+
+- Both inject full `using-superpowers` content (~1K tokens)
+- OpenCode plugin has separate compact-mode injection
+- Claude Code plugin could implement similar optimization
+
+**OpenCode implementation for reference:**
+
+```javascript
+if (event.type === 'session.compacted') {
+  await injectBootstrap(sessionID, true);  // compact version
+}
+```
+
+---
+
+## Impact
+
+### User Experience
+
+- **Workflow disruption:** Session becomes unusable mid-implementation
+- **Data loss risk:** Work lost when session hard-stops
+- **No recovery path:** Must restart in new session, losing context
+- **Unpredictable:** Users can't anticipate when failures will occur
+- **Reduced trust:** Users avoid Superpowers due to reliability issues
+
+### Plugin Adoption
+
+- Users may abandon Superpowers after failures
+- Documentation doesn't warn about token consumption patterns
+- Alternative mode (`executing-plans`) is safer but not promoted
+- Negative reputation for an otherwise valuable tool
+
+---
+
+## Proposed Solutions
+
+### Short-term (Documentation)
+
+1. **Add warning to `subagent-driven-development` skill:**
+
+   ```markdown
+   ⚠️ TOKEN USAGE WARNING:
+   This skill spawns 3+ subagents per task. For plans >5 tasks,
+   consider using 'executing-plans' to avoid token limit issues.
+
+   Estimated usage: ~300K tokens per task
+   ```
+
+2. **Update skill decision criteria:**
+   - Recommend `executing-plans` for plans >5 tasks
+   - Document token consumption patterns
+   - Explain trade-offs between modes
+
+3. **Create troubleshooting guide:**
+   - "If you hit hard-stop failures, switch to executing-plans"
+   - How to estimate token usage for your plan
+   - When to use each execution mode
+
+### Medium-term (Plugin Improvements)
+
+1. **Implement compact-mode injection:**
+   - Detect compaction events vs. session-start
+   - Inject abbreviated bootstrap (~200 tokens) post-compaction
+   - Follow OpenCode pattern
+
+2. **Add usage monitoring:**
+   - Track subagent dispatch count
+   - Warn when approaching estimated limits
+   - Suggest switching modes mid-workflow
+
+3. **Provide visibility:**
+   - TodoWrite shows: "16 subagents dispatched, ~400K tokens used"
+   - Warning at 10+ subagents: "Consider reviewing progress"
+   - Error-prevention instead of error-recovery
+
+### Long-term (Claude Code Architectural)
+
+1. **Isolated subagent token budgets:**
+   - Don't count subagent tokens against parent session limit
+   - Or provide much larger combined budget for subagent workflows
+   - Or implement proactive warnings before Task tool dispatch
+
+2. **Improved visibility:**
+   - Show cumulative token usage including subagents
+   - Display warning at >80% context consumption
+   - Indicate when compaction is struggling
+
+3. **Better compaction during active dispatch:**
+   - Detect when subagents are being spawned
+   - Proactively compact before Task tool invocations
+   - Prevent hitting hard limits through prediction
+
+---
+
+## Workaround (Immediate)
+
+**For users experiencing this issue:**
+
+1. **Switch to `executing-plans` mode:**
+   - Use when you have a written implementation plan
+   - Works in parallel session (separate context)
+   - No subagent multiplication
+   - Requires human review between batches
+
+2. **Or limit plan size when using `subagent-driven-development`:**
+   - Keep plans to ≤5 tasks when using subagent mode
+   - Break large features into multiple small plans
+   - Execute each small plan separately
+
+3. **Monitor for early warning signs:**
+   - Session feeling "slower"
+   - Tools taking longer to respond
+   - May indicate approaching token limits
+
+---
+
+## Related Issues
+
+- None found (please link if duplicates exist)
+
+---
+
+## Additional Data Available
+
+If helpful, I can provide:
+
+1. **Session transcripts** showing token usage patterns
+2. **Reproduction test case** with minimal project
+3. **Token analysis scripts** from the repository
+4. **Detailed research report** (see `TOKEN-CONSUMPTION-RESEARCH.md`)
+
+---
+
+## References
+
+- **Test data:** `tests/claude-code/test-subagent-driven-development-integration.sh`
+- **Token analysis:** `tests/claude-code/analyze-token-usage.py`
+- **Skills comparison:**
+  - `skills/subagent-driven-development/SKILL.md`
+  - `skills/executing-plans/SKILL.md`
+- **Hook implementation:** `hooks/session-start.sh`, `hooks/hooks.json`
+- **OpenCode compaction:** `.opencode/plugin/superpowers.js` (lines 206-212)
+
+---
+
+## Questions for Maintainers
+
+1. Is this a known limitation of the Claude Code architecture?
+2. Should the documentation explicitly warn about token consumption?
+3. Are there plans to implement isolated subagent token budgets?
+4. Would a PR implementing compact-mode injection be welcome?
+5. Should `executing-plans` be the default recommendation over `subagent-driven-development`?

--- a/docs/research/superpowers-token-consumption/HOOK-ANALYSIS-TOKEN-DETECTION.md
+++ b/docs/research/superpowers-token-consumption/HOOK-ANALYSIS-TOKEN-DETECTION.md
@@ -1,0 +1,499 @@
+# Hook Analysis: Token Exhaustion Detection
+
+**Question:** Is there a Claude Code hook that can detect incipient token exhaustion before it happens (e.g., at 40% remaining / 160K tokens used)?
+
+**Answer:** ❌ NO - No existing hook provides proactive token usage monitoring.
+
+---
+
+## Available Hooks Analysis
+
+### Hooks Examined (10 Total)
+
+From <https://code.claude.com/docs/en/hooks>:
+
+1. **PreToolUse** - Before tool execution
+2. **PermissionRequest** - Permission dialogs
+3. **PostToolUse** - After tool completion
+4. **UserPromptSubmit** - Before processing user input
+5. **Stop** - When main agent finishes responding
+6. **SubagentStop** - When subagent finishes responding
+7. **PreCompact** ⚠️ - Before compaction runs (closest match)
+8. **SessionStart** - Session initialization
+9. **SessionEnd** - Session termination
+10. **Notification** - System notifications
+
+---
+
+## Closest Match: PreCompact Hook ⚠️
+
+### Configuration
+
+```json
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "auto|manual",
+        "hooks": [{
+          "type": "command",
+          "command": "your-script.sh"
+        }]
+      }
+    ]
+  }
+}
+```
+
+### Matcher Options
+
+- **`manual`** - Triggered by `/compact` command
+- **`auto`** - Triggered when context is FULL and auto-compact runs
+
+### Context Provided
+
+```json
+{
+  "trigger": "manual" | "auto",
+  "custom_instructions": "..." // only for manual
+}
+```
+
+### Critical Limitation
+
+**PreCompact only fires AFTER context is already full** (for auto-compact), not at a threshold like 40% remaining.
+
+**Timeline:**
+
+```
+Token Usage:
+0K ────────── 80K ────────── 160K ────────── 200K
+              (40%)         (80%)          (FULL)
+                                              ↑
+                                    PreCompact fires here
+                                    (too late for prevention)
+```
+
+**What you need:**
+
+```
+Token Usage:
+0K ────────── 80K ────────── 160K ────────── 200K
+                            (80%)
+                              ↑
+                   Hook fires here (proactive)
+                   WARNING: 40% remaining
+```
+
+---
+
+## Why No Hook Works for Your Use Case
+
+### 1. No Token Metrics Exposed
+
+**None of the hooks provide:**
+
+- Current token usage count
+- Remaining token budget
+- Tokens consumed in this turn
+- Cache read token counts
+- Subagent token consumption
+
+**Hook input structure (common fields):**
+
+```json
+{
+  "session_id": "string",
+  "transcript_path": "/path/to/session.jsonl",
+  "cwd": "/path/to/project",
+  "permission_mode": "default",
+  "hook_event_name": "PreToolUse"
+  // ❌ NO token usage fields
+}
+```
+
+### 2. Hooks Are Event-Based, Not Metric-Based
+
+**Current hook triggers:**
+
+- Tool use events (before/after)
+- User actions (prompt submit)
+- Agent lifecycle (start/stop)
+- Compaction events (reactive)
+
+**Not available:**
+
+- Threshold-based triggers ("when tokens > X")
+- Metric monitoring ("every N tokens consumed")
+- Predictive warnings ("if current trend continues...")
+
+### 3. Transcript Analysis Required
+
+**You could parse transcript file yourself:**
+
+```bash
+# PreToolUse hook
+#!/bin/bash
+TRANSCRIPT_PATH="$1"  # Passed via hook context
+
+# Parse JSONL to count tokens
+python3 analyze-token-usage.py "$TRANSCRIPT_PATH"
+
+# If over threshold, warn somehow
+if [ $TOKENS -gt 160000 ]; then
+  echo '{"systemMessage": "⚠️ Token usage high"}' >&2
+fi
+```
+
+**Problems with this approach:**
+
+1. Transcript doesn't include current token counts
+2. Would need to estimate based on text length
+3. No access to cache read tokens
+4. No access to subagent tokens in parent context
+5. Inaccurate and unreliable
+
+---
+
+## Hook Comparison Table
+
+| Hook | Timing | Token Data? | Proactive? | Use for Detection? |
+|------|--------|-------------|------------|-------------------|
+| PreToolUse | Before tool | ❌ None | No | ❌ No |
+| PostToolUse | After tool | ❌ None | No | ❌ No |
+| Stop | Agent done | ❌ None | No | ❌ No |
+| SubagentStop | Subagent done | ❌ None | No | ❌ No |
+| PreCompact (manual) | User command | ❌ None | No | ❌ No |
+| PreCompact (auto) | Context FULL | ❌ None | **Reactive** | ⚠️ Too late |
+| SessionStart | Session init | ❌ None | No | ❌ No |
+| UserPromptSubmit | Before prompt | ❌ None | No | ❌ No |
+
+**Conclusion:** No hook provides the data or timing needed for proactive token exhaustion detection.
+
+---
+
+## Workarounds (All Have Limitations)
+
+### Option 1: Count Subagent Dispatches (Heuristic)
+
+**Approach:** Track Task tool invocations in PreToolUse hook
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [{
+          "type": "command",
+          "command": "/path/to/count-subagents.sh"
+        }]
+      }
+    ]
+  }
+}
+```
+
+**count-subagents.sh:**
+
+```bash
+#!/bin/bash
+
+# Read hook context
+CONTEXT=$(cat)
+SESSION_ID=$(echo "$CONTEXT" | jq -r '.session_id')
+
+# Increment counter file
+COUNTER_FILE="/tmp/subagent-count-${SESSION_ID}"
+COUNT=$(($(cat "$COUNTER_FILE" 2>/dev/null || echo 0) + 1))
+echo "$COUNT" > "$COUNTER_FILE"
+
+# Warn if high
+if [ "$COUNT" -gt 10 ]; then
+  echo '{
+    "systemMessage": "⚠️ WARNING: 10+ subagents dispatched. Token usage may be high. Consider using executing-plans mode.",
+    "hookSpecificOutput": {
+      "additionalContext": "Note: Heavy subagent usage detected. Monitor for token exhaustion."
+    }
+  }'
+else
+  echo '{"continue": true}'
+fi
+```
+
+**Limitations:**
+
+- Heuristic only (doesn't measure actual tokens)
+- Doesn't account for varying subagent sizes
+- Threshold (10) is arbitrary
+- Doesn't track cache reads
+
+### Option 2: Estimate from Transcript Size (Very Rough)
+
+**Approach:** Check transcript file size in UserPromptSubmit
+
+```bash
+#!/bin/bash
+CONTEXT=$(cat)
+TRANSCRIPT=$(echo "$CONTEXT" | jq -r '.transcript_path')
+
+# Rough estimation: 1 character ≈ 0.25 tokens
+FILE_SIZE=$(wc -c < "$TRANSCRIPT")
+ESTIMATED_TOKENS=$((FILE_SIZE / 4))
+
+if [ "$ESTIMATED_TOKENS" -gt 160000 ]; then
+  echo '{
+    "systemMessage": "⚠️ Token budget may be near limit",
+    "decision": "allow"
+  }'
+fi
+```
+
+**Limitations:**
+
+- Extremely inaccurate (characters ≠ tokens)
+- Doesn't account for prompt caching
+- Doesn't include subagent tokens
+- Transcript includes metadata, not just content
+- Unreliable for decision-making
+
+### Option 3: PreCompact Auto-Reactive Warning
+
+**Approach:** When auto-compact fires, warn that limit was reached
+
+```json
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "auto",
+        "hooks": [{
+          "type": "command",
+          "command": "/path/to/warn-compaction.sh"
+        }]
+      }
+    ]
+  }
+}
+```
+
+**warn-compaction.sh:**
+
+```bash
+#!/bin/bash
+
+echo "⚠️ AUTO-COMPACTION TRIGGERED: Token limit reached" >&2
+echo "If using subagent-driven-development, consider switching to executing-plans" >&2
+
+# Log to file for tracking
+echo "$(date): Auto-compaction triggered in session $SESSION_ID" >> /tmp/compaction.log
+
+# Allow compaction to proceed
+exit 0
+```
+
+**Limitations:**
+
+- Reactive, not proactive
+- Compaction already triggered (too late to prevent)
+- Cannot prevent hard-stop if compaction fails
+- Only logs the problem, doesn't solve it
+
+---
+
+## What's Actually Needed (Feature Request)
+
+### Proposed: TokenThreshold Hook
+
+**Trigger:** When token usage crosses configured thresholds
+
+**Configuration:**
+
+```json
+{
+  "hooks": {
+    "TokenThreshold": [
+      {
+        "threshold": 160000,
+        "percentage": 80,
+        "hooks": [{
+          "type": "command",
+          "command": "/path/to/token-warning.sh"
+        }]
+      },
+      {
+        "threshold": 180000,
+        "percentage": 90,
+        "hooks": [{
+          "type": "command",
+          "command": "/path/to/critical-warning.sh"
+        }]
+      }
+    ]
+  }
+}
+```
+
+**Context provided:**
+
+```json
+{
+  "session_id": "abc123",
+  "token_usage": {
+    "input_tokens": 5000,
+    "output_tokens": 8000,
+    "cache_creation_tokens": 2000,
+    "cache_read_tokens": 150000,
+    "total_consumed": 165000,
+    "limit": 200000,
+    "remaining": 35000,
+    "percentage_used": 82.5
+  },
+  "subagent_usage": {
+    "count": 12,
+    "total_tokens": 120000
+  },
+  "threshold_crossed": 160000,
+  "threshold_percentage": 80
+}
+```
+
+**Decision control:**
+
+```json
+{
+  "decision": "block",
+  "reason": "Token budget nearly exhausted. Switch to executing-plans mode.",
+  "systemMessage": "⚠️ 80% token budget used. Recommend checkpoint."
+}
+```
+
+**Use cases:**
+
+- Warn at 80% usage (160K)
+- Block Task tool at 90% usage (180K)
+- Force user review before continuing
+- Suggest switching execution modes
+- Log usage patterns for analysis
+
+### Proposed: TokenBudget Hook Modifier
+
+**Add token data to existing hooks:**
+
+```json
+{
+  "session_id": "abc123",
+  "token_budget": {
+    "used": 165000,
+    "limit": 200000,
+    "remaining": 35000,
+    "percentage": 82.5
+  },
+  // ... existing hook fields
+}
+```
+
+**Apply to these hooks:**
+
+- PreToolUse (decide whether to allow based on budget)
+- UserPromptSubmit (warn user before processing)
+- Stop (show token summary when agent finishes)
+- SubagentStop (track per-subagent consumption)
+
+---
+
+## Recommendations
+
+### For Immediate Use (Superpowers Plugin)
+
+**None of the current hooks can prevent token exhaustion proactively.**
+
+**Best available option: PreCompact (auto) reactive logging**
+
+```json
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "auto",
+        "hooks": [{
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/warn-auto-compact.sh"
+        }]
+      }
+    ]
+  }
+}
+```
+
+**Purpose:**
+
+- Log when compaction occurs
+- Track how often it happens
+- Gather data for bug report
+- Warn user after the fact
+
+**Does NOT prevent hard-stops** - only logs when they're about to happen.
+
+### For Feature Requests
+
+**File these with Claude Code team:**
+
+1. **TokenThreshold hook** (new hook type)
+   - Proactive threshold-based triggers
+   - Provides token usage metrics
+   - Allows preventive action
+
+2. **Token budget data in existing hooks** (enhancement)
+   - Add token usage to PreToolUse context
+   - Allow hooks to make informed decisions
+   - Enable user-written token management
+
+3. **Subagent token visibility** (transparency)
+   - Expose subagent token consumption to parent
+   - Include in TokenBudget data
+   - Enable accurate monitoring
+
+### For Superpowers Plugin Maintainers
+
+**Document the limitation:**
+
+```markdown
+⚠️ **Token Consumption Warning**
+
+The Claude Code hook system does not expose token usage metrics.
+This means we cannot proactively warn when approaching token limits.
+
+If using `subagent-driven-development`:
+- Monitor for auto-compaction events (indicates high usage)
+- Switch to `executing-plans` for large plans (>5 tasks)
+- Watch for session slowdowns (may indicate approaching limits)
+```
+
+---
+
+## Conclusion
+
+**Direct answer to your question:**
+
+❌ **NO** - There is no hook that can detect incipient token exhaustion at a threshold like 40% remaining (160K used).
+
+**Why:**
+
+- No hooks expose token usage metrics
+- PreCompact (auto) only fires when context is ALREADY FULL
+- Hooks are event-based, not metric-based
+- Token budgets are not visible to hook scripts
+
+**Closest option:**
+
+- **PreCompact (auto)** - Reactive logging when context fills
+- **Limitation:** Too late to prevent issues
+
+**What's needed:**
+
+- New **TokenThreshold** hook type
+- Token usage data in existing hook contexts
+- Proactive threshold-based triggers
+
+**This limitation should be included in your bug report** as evidence that the token consumption issue cannot currently be mitigated through hooks.

--- a/docs/research/superpowers-token-consumption/HOOK-IMPLEMENTATION-TOKEN-MONITORING.md
+++ b/docs/research/superpowers-token-consumption/HOOK-IMPLEMENTATION-TOKEN-MONITORING.md
@@ -1,0 +1,632 @@
+# Practical Implementation: Token Usage Monitoring via Hooks
+
+**Update:** Following user suggestion to use PostToolUse/SubagentStop hooks with transcript parsing.
+
+## YES - This Can Work! ✅
+
+**Method:** Parse the session transcript JSONL file in PostToolUse or SubagentStop hooks to calculate current token usage.
+
+---
+
+## How It Works
+
+### 1. Hook Context Provides Transcript Path
+
+Every hook receives:
+
+```json
+{
+  "transcript_path": "/path/to/session.jsonl",
+  "session_id": "abc123",
+  // ... other fields
+}
+```
+
+### 2. Transcript Contains Token Usage Data
+
+From the analyze-token-usage.py script, we know the JSONL format includes:
+
+**Main session messages:**
+
+```json
+{
+  "type": "assistant",
+  "message": {
+    "usage": {
+      "input_tokens": 27,
+      "output_tokens": 3996,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 1213703
+    }
+  }
+}
+```
+
+**Subagent tool results:**
+
+```json
+{
+  "type": "user",
+  "toolUseResult": {
+    "agentId": "3380c209",
+    "usage": {
+      "input_tokens": 2,
+      "output_tokens": 787,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 24989
+    }
+  }
+}
+```
+
+### 3. Parse and Sum to Get Current Usage
+
+Similar to `tests/claude-code/analyze-token-usage.py`, but simplified for real-time monitoring.
+
+---
+
+## Implementation Options
+
+### Option A: SubagentStop Hook (Recommended for Superpowers)
+
+**Why:** Catches every subagent completion, perfect for subagent-driven-development
+
+**Hook configuration:**
+
+```json
+{
+  "hooks": {
+    "SubagentStop": [
+      {
+        "hooks": [{
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/check-token-usage.sh"
+        }]
+      }
+    ]
+  }
+}
+```
+
+### Option B: PostToolUse Hook (Broader Coverage)
+
+**Why:** Fires after every tool use, including non-subagent tools
+
+**Hook configuration:**
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [{
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/check-token-usage.sh"
+        }]
+      }
+    ]
+  }
+}
+```
+
+**Note:** Matcher "Task" limits to subagent dispatch only. Use "*" for all tools.
+
+---
+
+## Implementation Script
+
+### check-token-usage.sh
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read hook context from stdin
+CONTEXT=$(cat)
+TRANSCRIPT_PATH=$(echo "$CONTEXT" | jq -r '.transcript_path')
+SESSION_ID=$(echo "$CONTEXT" | jq -r '.session_id')
+
+# Parse transcript and calculate token usage
+USAGE=$(python3 "$(dirname "$0")/parse-token-usage.py" "$TRANSCRIPT_PATH")
+
+TOTAL_TOKENS=$(echo "$USAGE" | jq -r '.total_tokens')
+TOTAL_INPUT=$(echo "$USAGE" | jq -r '.total_input')
+SUBAGENT_COUNT=$(echo "$USAGE" | jq -r '.subagent_count')
+
+# Define thresholds
+LIMIT=200000
+WARN_THRESHOLD=160000    # 80%
+CRITICAL_THRESHOLD=180000 # 90%
+
+# Check thresholds and provide feedback
+if [ "$TOTAL_INPUT" -gt "$CRITICAL_THRESHOLD" ]; then
+  # CRITICAL: 90%+ used
+  echo '{
+    "systemMessage": "🚨 CRITICAL: 90% token budget used (' "$TOTAL_INPUT" '/' "$LIMIT" '). Strongly recommend switching to executing-plans mode or creating checkpoint.",
+    "hookSpecificOutput": {
+      "additionalContext": "⚠️ Token budget critical: '"$TOTAL_INPUT"'/200K used, '"$SUBAGENT_COUNT"' subagents dispatched."
+    }
+  }' | jq -c
+
+  # Log for analysis
+  echo "$(date) - CRITICAL: Session $SESSION_ID at $TOTAL_INPUT tokens ($SUBAGENT_COUNT subagents)" \
+    >> "${HOME}/.claude/token-warnings.log"
+
+elif [ "$TOTAL_INPUT" -gt "$WARN_THRESHOLD" ]; then
+  # WARNING: 80%+ used
+  echo '{
+    "systemMessage": "⚠️ WARNING: 80% token budget used (' "$TOTAL_INPUT" '/' "$LIMIT" '). Consider checkpointing or switching execution modes.",
+    "hookSpecificOutput": {
+      "additionalContext": "Token usage high: '"$TOTAL_INPUT"'/200K used, '"$SUBAGENT_COUNT"' subagents dispatched."
+    }
+  }' | jq -c
+
+  # Log for analysis
+  echo "$(date) - WARNING: Session $SESSION_ID at $TOTAL_INPUT tokens ($SUBAGENT_COUNT subagents)" \
+    >> "${HOME}/.claude/token-warnings.log"
+
+else
+  # Under threshold - allow silently
+  echo '{"continue": true}' | jq -c
+fi
+```
+
+### parse-token-usage.py
+
+```python
+#!/usr/bin/env python3
+"""
+Parse Claude Code session transcript to calculate total token usage.
+Simplified version of tests/claude-code/analyze-token-usage.py for real-time monitoring.
+"""
+
+import json
+import sys
+
+def calculate_usage(filepath):
+    total_usage = {
+        'input_tokens': 0,
+        'output_tokens': 0,
+        'cache_creation': 0,
+        'cache_read': 0,
+        'subagent_count': 0
+    }
+
+    try:
+        with open(filepath, 'r') as f:
+            for line in f:
+                try:
+                    data = json.loads(line)
+
+                    # Main session assistant messages
+                    if data.get('type') == 'assistant' and 'message' in data:
+                        usage = data['message'].get('usage', {})
+                        total_usage['input_tokens'] += usage.get('input_tokens', 0)
+                        total_usage['output_tokens'] += usage.get('output_tokens', 0)
+                        total_usage['cache_creation'] += usage.get('cache_creation_input_tokens', 0)
+                        total_usage['cache_read'] += usage.get('cache_read_input_tokens', 0)
+
+                    # Subagent tool results
+                    if data.get('type') == 'user' and 'toolUseResult' in data:
+                        result = data['toolUseResult']
+                        if 'usage' in result and 'agentId' in result:
+                            total_usage['subagent_count'] += 1
+                            usage = result['usage']
+                            total_usage['input_tokens'] += usage.get('input_tokens', 0)
+                            total_usage['output_tokens'] += usage.get('output_tokens', 0)
+                            total_usage['cache_creation'] += usage.get('cache_creation_input_tokens', 0)
+                            total_usage['cache_read'] += usage.get('cache_read_input_tokens', 0)
+                except:
+                    pass
+    except:
+        pass
+
+    # Calculate totals
+    total_input = (total_usage['input_tokens'] +
+                   total_usage['cache_creation'] +
+                   total_usage['cache_read'])
+    total_tokens = total_input + total_usage['output_tokens']
+
+    return {
+        'total_input': total_input,
+        'total_tokens': total_tokens,
+        'subagent_count': total_usage['subagent_count'],
+        'breakdown': total_usage
+    }
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(json.dumps({'total_input': 0, 'total_tokens': 0, 'subagent_count': 0}))
+        sys.exit(0)
+
+    usage = calculate_usage(sys.argv[1])
+    print(json.dumps(usage))
+```
+
+---
+
+## Installation for Superpowers Plugin
+
+### 1. Add Scripts to Plugin
+
+```bash
+cd /path/to/superpowers
+chmod +x hooks/check-token-usage.sh
+chmod +x hooks/parse-token-usage.py
+```
+
+### 2. Update hooks/hooks.json
+
+**For SubagentStop monitoring:**
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [{
+          "type": "command",
+          "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start.sh"
+        }]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [{
+          "type": "command",
+          "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/check-token-usage.sh\""
+        }]
+      }
+    ]
+  }
+}
+```
+
+**For PostToolUse monitoring (Task tool only):**
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [{
+          "type": "command",
+          "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start.sh"
+        }]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [{
+          "type": "command",
+          "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/check-token-usage.sh\""
+        }]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Behavior Examples
+
+### Scenario 1: Under Threshold
+
+**Situation:** 5 subagents dispatched, 120K tokens used
+
+**Hook behavior:**
+
+- Runs silently
+- Allows continuation
+- No user message
+
+### Scenario 2: Warning Threshold (80%)
+
+**Situation:** 12 subagents dispatched, 165K tokens used
+
+**User sees:**
+
+```
+⚠️ WARNING: 80% token budget used (165000/200000).
+Consider checkpointing or switching execution modes.
+```
+
+**Claude sees additional context:**
+
+```
+Token usage high: 165000/200K used, 12 subagents dispatched.
+```
+
+**Log entry:**
+
+```
+2026-01-16 18:30:45 - WARNING: Session abc123 at 165000 tokens (12 subagents)
+```
+
+### Scenario 3: Critical Threshold (90%)
+
+**Situation:** 18 subagents dispatched, 185K tokens used
+
+**User sees:**
+
+```
+🚨 CRITICAL: 90% token budget used (185000/200000).
+Strongly recommend switching to executing-plans mode or creating checkpoint.
+```
+
+**Claude sees additional context:**
+
+```
+⚠️ Token budget critical: 185000/200K used, 18 subagents dispatched.
+```
+
+**Result:** User can make informed decision to:
+
+- Stop current workflow
+- Switch to executing-plans mode
+- Create a checkpoint and start fresh session
+- Review progress and compact manually
+
+---
+
+## Advantages of This Approach
+
+### ✅ Proactive Warning
+
+- Catches issues at 80% (160K), well before hard-stop
+- Gives user time to react and adjust workflow
+- Prevents work loss from unexpected hard-stops
+
+### ✅ Accurate Measurement
+
+- Uses actual token data from Claude API responses
+- Includes subagent consumption
+- Accounts for cache read tokens
+- No estimation or guessing
+
+### ✅ Actionable Context
+
+- Shows both user warning and Claude context
+- Provides specific numbers (165K/200K)
+- Indicates subagent count for root cause
+- Logs for pattern analysis
+
+### ✅ Minimal Performance Impact
+
+- Only runs after subagent completion
+- Python script is fast (< 100ms for typical transcripts)
+- No blocking of normal operations
+
+### ✅ User Control
+
+- Can adjust thresholds (80%, 90%)
+- Can choose which hook (SubagentStop vs PostToolUse)
+- Can customize messaging
+- Can log to preferred location
+
+---
+
+## Limitations & Considerations
+
+### 1. Reactive, Not Preventive
+
+**Still fires AFTER consumption, not before:**
+
+- Subagent has already run and consumed tokens
+- Can't prevent individual subagent dispatch
+- Can only warn after pattern emerges
+
+**Mitigation:**
+
+- Warn early enough (80%) to allow adjustment
+- User can stop workflow before critical (90%)
+
+### 2. Per-Event Overhead
+
+**Hook runs after every subagent:**
+
+- 16 subagents = 16 hook invocations
+- Each parses entire transcript
+- Overhead grows with session length
+
+**Mitigation:**
+
+- Parsing is fast (< 100ms)
+- Only processes new data incrementally
+- Could cache previous counts
+
+### 3. Transcript File Locking
+
+**Potential race condition:**
+
+- Claude may be writing to transcript
+- Hook reading at same time
+- Could get incomplete read
+
+**Mitigation:**
+
+- Python json.loads handles truncated lines gracefully
+- Worst case: undercounts (safe direction)
+- Next invocation will catch up
+
+### 4. Assumes 200K Limit
+
+**Hardcoded in script:**
+
+```bash
+LIMIT=200000
+```
+
+**If limit changes:**
+
+- Script needs updating
+- Or make configurable via env var
+
+**Better approach:**
+
+```bash
+LIMIT=${CLAUDE_TOKEN_LIMIT:-200000}
+```
+
+---
+
+## Enhanced Version: Blocking at Critical
+
+**For maximum protection**, modify to BLOCK at critical threshold:
+
+```bash
+if [ "$TOTAL_INPUT" -gt "$CRITICAL_THRESHOLD" ]; then
+  echo '{
+    "decision": "block",
+    "reason": "Token budget at 90% ('"$TOTAL_INPUT"'/200K). Workflow stopped to prevent hard-stop failure. Recommend: (1) Use /compact to compact context, (2) Switch to executing-plans mode, or (3) Continue in new session.",
+    "systemMessage": "🚨 Token budget critical - workflow paused for safety"
+  }' | jq -c
+  exit 2  # Blocking error
+fi
+```
+
+**Effect:**
+
+- SubagentStop hook returns blocking decision
+- Agent cannot continue current workflow
+- User must take action (compact, switch modes, new session)
+- Prevents invisible hard-stop later
+
+**Trade-off:**
+
+- More disruptive to workflow
+- But prevents catastrophic failure
+- User has clear path forward
+
+---
+
+## Testing the Implementation
+
+### 1. Create Test Script
+
+```bash
+# test-token-hook.sh
+#!/bin/bash
+
+# Simulate hook context with test transcript
+TEST_TRANSCRIPT="/path/to/test-session.jsonl"
+TEST_CONTEXT='{
+  "transcript_path": "'"$TEST_TRANSCRIPT"'",
+  "session_id": "test-123",
+  "hook_event_name": "SubagentStop"
+}'
+
+echo "$TEST_CONTEXT" | ./hooks/check-token-usage.sh
+```
+
+### 2. Run with Known Data
+
+Use the test data from `tests/claude-code/`:
+
+```bash
+# Should show 1,524,058 total tokens, 7 subagents
+./test-token-hook.sh
+```
+
+### 3. Verify Thresholds
+
+Modify test transcript to add/remove messages until:
+
+- Under 160K (no warning)
+- 160K-180K (warning)
+- Over 180K (critical)
+
+---
+
+## Recommended Configuration for Superpowers
+
+**Add to `hooks/hooks.json`:**
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [{
+          "type": "command",
+          "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start.sh"
+        }]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [{
+          "type": "command",
+          "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/check-token-usage.sh\""
+        }]
+      }
+    ]
+  }
+}
+```
+
+**Why SubagentStop?**
+
+- Catches the primary token consumption pattern (subagents)
+- Fires at natural checkpoints (after each subagent)
+- Most relevant for subagent-driven-development workflow
+- Lower overhead than PostToolUse(*) which fires for ALL tools
+
+---
+
+## Documentation Updates Needed
+
+### In subagent-driven-development/SKILL.md
+
+Add warning section:
+
+```markdown
+## Token Consumption Monitoring
+
+⚠️ **Automatic Warning System**
+
+The plugin monitors token usage and will warn you when:
+- **80% used (160K)**: Warning - consider checkpointing
+- **90% used (180K)**: Critical - strongly recommend stopping
+
+If you see these warnings:
+1. Review your progress
+2. Consider using `/compact` to compact context
+3. Switch to `executing-plans` mode for remaining tasks
+4. Or start fresh session and continue from checkpoint
+
+**Token estimates:**
+- Small plan (≤5 tasks): ~150K tokens
+- Medium plan (10 tasks): ~300K tokens
+- Large plan (20 tasks): ~600K tokens
+
+Plans >5 tasks may exceed the 200K limit.
+```
+
+---
+
+## Summary
+
+**Yes, this approach works!** ✅
+
+**Implementation:**
+
+1. Use SubagentStop hook (or PostToolUse with Task matcher)
+2. Parse transcript JSONL to sum token usage
+3. Warn at 80% (160K), critical at 90% (180K)
+4. Provide actionable guidance to user
+
+**Benefits:**
+
+- Proactive warnings before hard-stop
+- Accurate measurement (not estimation)
+- Minimal performance impact
+- User can adjust workflow before failure
+
+**This should be added to Superpowers plugin** to mitigate the token exhaustion issue while waiting for architectural fixes from Claude Code team.

--- a/docs/research/superpowers-token-consumption/README.md
+++ b/docs/research/superpowers-token-consumption/README.md
@@ -1,0 +1,49 @@
+# Superpowers token-consumption research
+
+Preserved 2026-09-11 from `~/Developer/superpowers`, a local clone of
+`obra/superpowers` that was removed as part of retiring two forked copies.
+These files were **untracked** in that clone — no commit, no remote, no other
+copy. They are the origin of the context-overload work and are kept here
+because deleting the clone would have destroyed them.
+
+## What's here
+
+| File | Date | What it is |
+| --- | --- | --- |
+| `TOKEN-CONSUMPTION-RESEARCH.md` | 2026-01-16 | Measurement of subagent token usage under `subagent-driven-development`; the original investigation |
+| `DRAFT-BUG-REPORT.md` | 2026-01-16 | Unsent bug report: hard-stop token failures despite auto-compaction |
+| `HOOK-ANALYSIS-TOKEN-DETECTION.md` | 2026-01-16 | Whether any hook can detect incipient token exhaustion. Conclusion: no |
+| `HOOK-IMPLEMENTATION-TOKEN-MONITORING.md` | 2026-01-16 | Follow-up design: parse session transcript JSONL in PostToolUse/SubagentStop |
+| `hooks-backup-v6.3.0/` | 2026-09-11 | The superpowers v6.3.0 `hooks/` directory, removed from the plugin cache to stop SessionStart injection |
+
+`CLAUDE.md` from that clone was **not** preserved — it was upstream's
+contributor guidance, not original research.
+
+## Why the hooks backup exists
+
+superpowers v6.3.0 ships a `SessionStart` hook that injects the full
+`using-superpowers` SKILL.md into every session, on `startup|clear|compact`.
+On 2026-07-31 that injection was removed in a personal fork
+(`smartwatermelon/superpowers@18821ef`) by deleting the `hooks/` directory
+outright, and the marketplace copy was pointed at that fork.
+
+By 2026-09-11 the cache had moved to upstream v6.3.0 and the injection was
+live again — the fork's fix was no longer in effect. Rather than maintain a
+fork, the same removal was applied directly to the plugin cache at
+`~/.claude/plugins/cache/superpowers-marketplace/superpowers/6.3.0/hooks`.
+This backup is that directory, so the change can be inspected or reverted.
+
+Both forked copies (`smartwatermelon/superpowers` and
+`smartwatermelon/superpowers-marketplace`) were archived on 2026-09-11.
+
+## Known fragility
+
+The fix edits the **plugin cache**, which a superpowers update or reinstall
+will overwrite, restoring the hook. The marketplace manifest points at
+`obra/superpowers.git` and is refreshed on marketplace update, so there is no
+durable pin either. If the injection returns, delete `hooks/` from the new
+version's cache directory.
+
+Tracked as [dev-env#126](https://github.com/smartwatermelon/dev-env/issues/126),
+which asks the real question: build something that defeats the injection
+durably, or stop using superpowers.

--- a/docs/research/superpowers-token-consumption/TOKEN-CONSUMPTION-RESEARCH.md
+++ b/docs/research/superpowers-token-consumption/TOKEN-CONSUMPTION-RESEARCH.md
@@ -1,0 +1,375 @@
+# Token Consumption Research Report
+
+## Superpowers Plugin - Subagent Token Usage Analysis
+
+**Date:** 2026-01-16
+**Researcher:** Claude Code (Sonnet 4.5)
+**Issue:** Hard-stop token limit failures despite auto-compaction enabled
+
+---
+
+## Executive Summary
+
+This research investigates whether heavy subagent usage by the Superpowers plugin causes invisible token consumption that leads to hard-stop failures in Claude Code sessions, even when auto-compaction is enabled.
+
+**Conclusion:** YES. The evidence strongly supports the hypothesis that `subagent-driven-development`'s heavy subagent usage invisibly consumes massive token budgets, potentially exceeding Claude Code's 200K context limit by 7.5x or more for moderate-sized implementation plans.
+
+---
+
+## Background
+
+### User Observation
+
+- **Symptom:** Hard-stop token limit failures with no auto-compaction recovery
+- **Pattern:** Only occurs when using Superpowers plugin workflows
+- **Configuration:** Auto-compaction is enabled
+- **Control:** No failures observed when using Claude Code without Superpowers
+
+### Research Question
+
+Does heavy subagent use by Superpowers invisibly consume the parent session's token limit, or is there another mechanism causing the observed failures?
+
+---
+
+## Findings
+
+### 1. Subagent Usage Patterns
+
+#### `subagent-driven-development` Skill
+
+**Subagent multiplication per task:**
+
+- 1× Implementer subagent (implements with TDD)
+- 1× Spec compliance reviewer subagent (verifies requirements match)
+- 1× Code quality reviewer subagent (code review)
+- Review loops spawn additional subagents when issues found
+- Final code reviewer for entire implementation
+
+**Scale example:**
+
+```
+5-task implementation plan:
+- 5 implementer subagents
+- 5 spec reviewer subagents
+- 5 code quality reviewer subagents
+- 1 final reviewer
+= 16 subagents minimum
+= 20+ with typical review loops
+```
+
+#### `executing-plans` Skill (Alternative Mode)
+
+**No subagent usage:**
+
+- Executes in parallel Claude Code session
+- Agent executes tasks directly (no Task tool dispatch)
+- Human-in-the-loop review between batches
+- Traditional context accumulation only
+
+---
+
+### 2. Token Consumption Evidence
+
+#### Test Data Analysis
+
+From `docs/testing.md` - Integration test with 5 tasks, 7 subagents:
+
+```
+Token Usage Breakdown:
+─────────────────────────────────────────────────────
+Main session:         1,213,703 cache read tokens
+Subagents (7 total):  1,382,835 cache read tokens
+Total input:          1,515,639 tokens
+Total:                1,524,058 tokens
+Cost:                 $4.67
+─────────────────────────────────────────────────────
+```
+
+**Key observations:**
+
+- **1.5M tokens** for a minimal 5-task test case
+- **7.5x** the Claude Code 200K context limit
+- Subagent cache reads alone: **1.4M tokens**
+- Per-subagent overhead: **~20-25K cache read tokens**
+
+#### Extrapolation for Real-World Usage
+
+```
+10-task plan (moderate complexity):
+- ~32 subagents (3×10 + 2 reviews)
+- ~800K cache read tokens (subagents only)
+- ~3M+ total tokens with main session context
+
+20-task plan (complex feature):
+- ~64 subagents
+- ~1.6M cache read tokens (subagents only)
+- ~6M+ total tokens
+```
+
+---
+
+### 3. Context Injection Size
+
+#### SessionStart Hook (`hooks/session-start.sh`)
+
+**Injected content:**
+
+- `using-superpowers` skill: **3,798 bytes** (~1,000 tokens)
+- Re-injected on **every** compaction event
+- No distinction between session-start and post-compaction
+
+**Comparison with OpenCode implementation:**
+
+```javascript
+// OpenCode has explicit compact mode
+if (event.type === 'session.compacted') {
+  await injectBootstrap(sessionID, true);  // compact version
+}
+```
+
+**Gap:** Claude Code plugin doesn't implement compact-mode injection.
+
+#### Skill Content Accumulation
+
+Skills invoked during typical workflow:
+
+```
+brainstorming:              ~22 KB
+writing-plans:              ~4 KB
+subagent-driven-development: ~10 KB
+test-driven-development:     ~10 KB
+systematic-debugging:        ~10 KB
+Total:                       ~56 KB (~14,000 tokens)
+```
+
+Plus supporting files (anti-patterns, techniques, templates): **~100 KB total** (~25,000 tokens)
+
+---
+
+### 4. Compaction Interference Analysis
+
+#### Hook Configuration
+
+```json
+// hooks/hooks.json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [{
+          "type": "command",
+          "command": "session-start.sh"
+        }]
+      }
+    ]
+  }
+}
+```
+
+**Behavior on compaction:**
+
+1. Compaction event triggers
+2. SessionStart hook fires (matches "compact")
+3. Full `using-superpowers` content re-injected (~1,000 tokens)
+4. No size reduction vs. initial injection
+
+**Potential issue:** If compaction occurs during active subagent dispatch, re-injection may interfere with space recovery.
+
+---
+
+### 5. Token Accounting Architecture Questions
+
+**Unknown (requires Anthropic/Claude Code team clarification):**
+
+1. **Do subagent tokens count against parent session limit?**
+   - Session transcripts show separate `agentId` fields for subagents
+   - Token usage tracked separately in JSONL logs
+   - **Unknown:** Whether they share a 200K budget or have isolated limits
+
+2. **How does auto-compaction handle active subagent dispatch?**
+   - If parent session is at 180K tokens and spawns a 25K-token subagent
+   - Does this trigger immediate compaction?
+   - Can compaction recover space while subagents are running?
+
+3. **Is prompt caching shared between parent and subagents?**
+   - Cache read tokens dominate usage (1.4M of 1.5M)
+   - Are these counted toward context limit?
+   - Does each subagent create separate cache entries?
+
+---
+
+## Supporting Evidence
+
+### Why This Explains the Observed Behavior
+
+1. ✅ **Invisible to user:** Subagent token usage happens in background via Task tool
+2. ✅ **Scale is massive:** 7.5x limit for 5-task test, 15-30x for real-world plans
+3. ✅ **Pattern matches:** Only occurs with Superpowers, not without
+4. ✅ **Compaction can't help:** If actively spawning 25K-token subagents near limit, compaction can't free space fast enough
+5. ✅ **Hard-stop instead of recovery:** Suggests hitting architectural limit, not just needing cleanup
+
+### Alternative Hypotheses Considered
+
+**Hypothesis A:** Skill content size accumulation
+
+- **Evidence:** ~25K tokens for all skills combined
+- **Verdict:** Contributing factor but insufficient alone (12.5% of 200K limit)
+
+**Hypothesis B:** Compaction re-injection interference
+
+- **Evidence:** 1K tokens per re-injection
+- **Verdict:** Unlikely to be primary cause given small size
+
+**Hypothesis C:** Subagent tokens count toward parent limit ← PRIMARY HYPOTHESIS
+
+- **Evidence:** 1.5M tokens for 5 tasks
+- **Verdict:** Most likely explanation for hard-stop failures
+
+---
+
+## Skill Comparison: Avoiding the Issue
+
+### `executing-plans` - NO SUBAGENT TOKEN ISSUE
+
+```
+Execution model:
+- Parallel Claude Code session (separate context)
+- Agent executes tasks directly (no Task tool)
+- Human review between 3-task batches
+- Traditional token accumulation only
+
+Token characteristics:
+- Session's own work only
+- No subagent multiplication
+- Compaction effective (no active dispatch interference)
+- Slower but predictable
+```
+
+### `subagent-driven-development` - HEAVY SUBAGENT USE
+
+```
+Execution model:
+- Same session (shares parent context)
+- 3+ subagents per task via Task tool
+- Fully autonomous (no human checkpoints)
+- Review loops add more subagents
+
+Token characteristics:
+- 3-30x parent session limit for real-world plans
+- Each subagent: ~25K cache read tokens
+- Invisible consumption via background Tool results
+- Fast but unpredictable token exhaustion
+```
+
+---
+
+## Recommendations
+
+### For Users (Immediate Workaround)
+
+**Switch to `executing-plans` mode:**
+
+```
+When planning implementation → Choose parallel session execution
+- Slower (human reviews between batches)
+- Token-safe (no subagent multiplication)
+- Predictable resource usage
+```
+
+**Decision tree:**
+
+```
+Need to execute an implementation plan?
+├─ Small plan (≤5 tasks) + willing to risk token issues?
+│  └─ Use: subagent-driven-development
+└─ Moderate-large plan (>5 tasks) OR need reliability?
+   └─ Use: executing-plans
+```
+
+### For Plugin Maintainers
+
+1. **Document token consumption patterns**
+   - Add warning to `subagent-driven-development` skill
+   - Provide guidance: "For plans >5 tasks, consider executing-plans"
+   - Include estimated token usage: ~300K per task with subagent mode
+
+2. **Implement compact-mode injection** (like OpenCode)
+   - Detect compaction events vs. session-start
+   - Inject abbreviated bootstrap content post-compaction
+   - Reduce re-injection from 1K tokens to ~200 tokens
+
+3. **Add usage monitoring**
+   - Track subagent dispatch count in TodoWrite
+   - Warn when approaching token limits
+   - Suggest switching to executing-plans mid-workflow
+
+### For Claude Code Team (Architectural)
+
+1. **Clarify token accounting model**
+   - Document whether subagent tokens count toward parent limit
+   - Specify how prompt caching interacts with context limits
+   - Explain compaction behavior during active subagent dispatch
+
+2. **Consider isolated subagent budgets**
+   - If subagents share parent budget, consider isolation
+   - Or implement warnings when subagent dispatch approaches limits
+   - Prevent hard-stops by proactive compaction before Task tool use
+
+3. **Improve visibility**
+   - Show cumulative token usage including subagents
+   - Display warning when >80% of context consumed
+   - Indicate when auto-compaction is struggling to free space
+
+---
+
+## Test Data References
+
+### Integration Test Results
+
+**Source:** `tests/claude-code/test-subagent-driven-development-integration.sh`
+
+**Test scenario:** 5-task Node.js project with add/multiply functions
+
+**Results:**
+
+```
+Subagents dispatched: 7
+Token usage:
+  Main session:    27 input, 3,996 output, 1,213,703 cache read
+  Subagent avg:    ~4 input, ~650 output, ~23,000 cache read
+  Total:           1,524,058 tokens
+  Cost:            $4.67
+
+Files in test project:
+  src/math.js
+  test/math.test.js
+  package.json
+```
+
+**Implications:** Even minimal test cases show 7.5x context limit consumption.
+
+---
+
+## Related Files
+
+- `skills/subagent-driven-development/SKILL.md` - Heavy subagent mode
+- `skills/executing-plans/SKILL.md` - No-subagent alternative
+- `hooks/session-start.sh` - Context injection mechanism
+- `.opencode/plugin/superpowers.js` - Compaction handling (OpenCode)
+- `tests/claude-code/analyze-token-usage.py` - Token analysis tool
+- `docs/testing.md` - Integration test documentation
+
+---
+
+## Conclusion
+
+The evidence conclusively supports the hypothesis that `subagent-driven-development`'s heavy subagent usage causes invisible token consumption that can exceed Claude Code's context limit by 7.5-30x for real-world implementation plans.
+
+**Recommended actions:**
+
+1. **Users:** Switch to `executing-plans` for reliability
+2. **Maintainers:** Document token usage and implement compact-mode injection
+3. **Claude Code Team:** Clarify token accounting and improve visibility
+
+This is a legitimate bug/architectural issue warranting investigation and either documentation updates or architectural changes to prevent hard-stop failures.

--- a/docs/research/superpowers-token-consumption/hooks-backup-v6.3.0/hooks-cursor.json
+++ b/docs/research/superpowers-token-consumption/hooks-backup-v6.3.0/hooks-cursor.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "./hooks/run-hook.cmd session-start"
+      }
+    ]
+  }
+}

--- a/docs/research/superpowers-token-consumption/hooks-backup-v6.3.0/hooks.json
+++ b/docs/research/superpowers-token-consumption/hooks-backup-v6.3.0/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "shell": "bash",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/research/superpowers-token-consumption/hooks-backup-v6.3.0/run-hook.cmd
+++ b/docs/research/superpowers-token-consumption/hooks-backup-v6.3.0/run-hook.cmd
@@ -1,0 +1,46 @@
+: << 'CMDBLOCK'
+@echo off
+REM Cross-platform polyglot wrapper for hook scripts.
+REM On Windows: cmd.exe runs the batch portion, which finds and calls bash.
+REM On Unix: the shell interprets this as a script (: is a no-op in bash).
+REM
+REM Hook scripts use extensionless filenames (e.g. "session-start" not
+REM "session-start.sh") so Claude Code's Windows auto-detection -- which
+REM prepends "bash" to any command containing .sh -- doesn't interfere.
+REM
+REM Usage: run-hook.cmd <script-name> [args...]
+
+if "%~1"=="" (
+    echo run-hook.cmd: missing script name >&2
+    exit /b 1
+)
+
+set "HOOK_DIR=%~dp0"
+
+REM Try Git for Windows bash in standard locations
+if exist "C:\Program Files\Git\bin\bash.exe" (
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+REM Try bash on PATH (e.g. user-installed Git Bash, MSYS2, Cygwin)
+where bash >nul 2>nul
+if %ERRORLEVEL% equ 0 (
+    bash "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+REM No bash found - exit silently rather than error
+REM (plugin still works, just without SessionStart context injection)
+exit /b 0
+CMDBLOCK
+
+# Unix: run the named script directly
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_NAME="$1"
+shift
+exec bash "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"

--- a/docs/research/superpowers-token-consumption/hooks-backup-v6.3.0/session-start
+++ b/docs/research/superpowers-token-consumption/hooks-backup-v6.3.0/session-start
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# SessionStart hook for superpowers plugin
+
+set -euo pipefail
+
+# Determine plugin root directory
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Read using-superpowers content
+using_superpowers_content=$(cat "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" 2>&1 || echo "Error reading using-superpowers skill")
+
+# Escape string for JSON embedding using bash parameter substitution.
+# Each ${s//old/new} is a single C-level pass - orders of magnitude
+# faster than the character-by-character loop this replaces.
+escape_for_json() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+
+using_superpowers_escaped=$(escape_for_json "$using_superpowers_content")
+session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n</EXTREMELY_IMPORTANT>"
+
+# Output context injection as JSON.
+# Cursor hooks expect additional_context (snake_case).
+# Claude Code hooks expect hookSpecificOutput.additionalContext (nested).
+# Copilot CLI (v1.0.11+) and others expect additionalContext (top-level, SDK standard).
+# Claude Code reads BOTH additional_context and hookSpecificOutput without
+# deduplication, so we must emit only the field the current platform consumes.
+#
+# Uses printf instead of heredoc to work around bash 5.3+ heredoc hang.
+# See: https://github.com/obra/superpowers/issues/571
+if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
+  # Cursor sets CURSOR_PLUGIN_ROOT (may also set CLAUDE_PLUGIN_ROOT)
+  printf '{\n  "additional_context": "%s"\n}\n' "$session_context" | cat
+elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
+  # Claude Code sets CLAUDE_PLUGIN_ROOT without COPILOT_CLI
+  printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$session_context" | cat
+else
+  # Copilot CLI (sets COPILOT_CLI=1) or unknown platform — SDK standard format
+  printf '{\n  "additionalContext": "%s"\n}\n' "$session_context" | cat
+fi
+
+exit 0


### PR DESCRIPTION
## What

Preserves ~1,750 lines of original research that was untracked in a local
clone of `obra/superpowers`, plus the plugin hook directory removed to stop
superpowers' forced per-session context injection.

## Why this exists

The four research documents (2026-01-16) had **no commit, no remote, and no
second copy**. They lived only as untracked files in someone else's repo
checkout. Removing that clone — which happened as part of retiring two forked
superpowers copies — would have destroyed them silently.

They are the origin of the context-overload work:

| File | What |
| --- | --- |
| `TOKEN-CONSUMPTION-RESEARCH.md` | Measures subagent token usage; 1.5M tokens for a 5-task plan, 7.5× the context limit |
| `DRAFT-BUG-REPORT.md` | Unsent report on hard-stop failures despite auto-compaction |
| `HOOK-ANALYSIS-TOKEN-DETECTION.md` | Can a hook detect incipient exhaustion? Conclusion: no |
| `HOOK-IMPLEMENTATION-TOKEN-MONITORING.md` | Follow-up design: parse transcript JSONL in PostToolUse/SubagentStop |

`hooks-backup-v6.3.0/` captures the `SessionStart` hook directory deleted from
the live plugin cache to stop `using-superpowers` being injected into every
session.

## Verification

- Copies byte-verified with `diff` against the originals **before** the clone
  was removed.
- Upstream's `CLAUDE.md` deliberately excluded — contributor guidance, not
  research.
- `shellcheck -S info` clean on `session-start`.
- markdownlint reformatted the four documents: 88 blank-line insertions
  (MD022/MD032) and one bare URL wrapped (MD034). Diff inspected line by line;
  **no prose or data altered**.

## The part worth knowing

This injection was already fixed once — a fork deleted `hooks/` on 2026-07-31
(`smartwatermelon/superpowers@18821ef`) — and it **silently came back** when
the plugin cache updated to upstream v6.3.0 on 2026-08-19. Nobody noticed for
three weeks.

The current fix edits the plugin cache and carries exactly the same exposure:
any superpowers update or reinstall restores the hook, and nothing detects it.
That fragility is documented in the README rather than left as folklore.

Advances #126, which asks the actual question — build something that defeats
the injection durably, or stop using superpowers.

https://claude.ai/code/session_01ESsw699T54JHARkQXrdL3o
